### PR TITLE
Feature/sn 038 add weather city select page logic

### DIFF
--- a/lib/data/repositories/city_select_repository.dart
+++ b/lib/data/repositories/city_select_repository.dart
@@ -1,31 +1,42 @@
 import 'package:ses_novajoj/foundation/data/result.dart';
-//import 'package:ses_novajoj/networking/api/my_web_api.dart';
-// import 'package:ses_novajoj/networking/response/city_select_parameter_response.dart';
-// import 'package:ses_novajoj/networking/request/city_select_item_parameter.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/networking/api/weather_web_api.dart';
+import 'package:ses_novajoj/networking/response/city_select_item_response.dart';
+import 'package:ses_novajoj/networking/request/city_item_parameter.dart';
 import 'package:ses_novajoj/domain/entities/city_select_item.dart';
 import 'package:ses_novajoj/domain/repositories/city_select_repository.dart';
 
 /// TODO: This is dummy Web API class.
 /// You should  web api class is defined in its dart file, like `my_web_api.dart`
-class MyWebApi {}
 
 class CitySelectRepositoryImpl extends CitySelectRepository {
-  final MyWebApi _api;
+  final WeatherWebApi _api;
 
   // sigleton
   static final CitySelectRepositoryImpl _instance =
       CitySelectRepositoryImpl._internal();
-  CitySelectRepositoryImpl._internal() : _api = MyWebApi();
+  CitySelectRepositoryImpl._internal() : _api = WeatherWebApi();
   factory CitySelectRepositoryImpl() => _instance;
 
   @override
-  Future<Result<CitySelectItem>> fetchCitySelect(
-
+  Future<Result<CitySelectItem>> fetchCityInfos(
       {required FetchCitySelectRepoInput input}) async {
-    Result<CitySelectItem> result =
-        Result.success(data: CitySelectItem(id: 9999, string: "9999"));    // TODO: call api
+    Result<CitySelectItemRes> result = await _api.getWeatherCities(
+        paramter: CitytItemParameter(cityInfo: input.cityInfo));
 
-    // TODO: change api result for `CitySelect' repository
-    return result;
+    late Result<CitySelectItem> ret;
+    late CitySelectItem retVal;
+
+    result.when(success: (response) {
+      if (response.cityInfos != null) {
+        retVal = CitySelectItem(cityInfos: response.cityInfos ?? []);
+      } else {
+        assert(false, "Unresolved error: response is null");
+      }
+      ret = Result.success(data: retVal);
+    }, failure: (error) {
+      ret = Result.failure(error: error);
+    });
+    return ret;
   }
 }

--- a/lib/data/repositories/city_select_repository.dart
+++ b/lib/data/repositories/city_select_repository.dart
@@ -1,13 +1,9 @@
 import 'package:ses_novajoj/foundation/data/result.dart';
-import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/networking/api/weather_web_api.dart';
 import 'package:ses_novajoj/networking/response/city_select_item_response.dart';
 import 'package:ses_novajoj/networking/request/city_item_parameter.dart';
 import 'package:ses_novajoj/domain/entities/city_select_item.dart';
 import 'package:ses_novajoj/domain/repositories/city_select_repository.dart';
-
-/// TODO: This is dummy Web API class.
-/// You should  web api class is defined in its dart file, like `my_web_api.dart`
 
 class CitySelectRepositoryImpl extends CitySelectRepository {
   final WeatherWebApi _api;

--- a/lib/data/repositories/misc_info_list_repository.dart
+++ b/lib/data/repositories/misc_info_list_repository.dart
@@ -139,25 +139,25 @@ class MiscInfoListRepositoryImpl extends MiscInfoListRepository {
     return () {
       switch (hourOffset) {
         case '-10:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Hawaii');
+          return CityInfoDescript.fromCurrentLocale(name: 'Hawaii');
         case '-5:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Sao Paulo');
+          return CityInfoDescript.fromCurrentLocale(name: 'Sao Paulo');
         case '+0:00':
-          return CityInfoDescript.asCurrentLocale(name: 'London');
+          return CityInfoDescript.fromCurrentLocale(name: 'London');
         case '+1:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Paris');
+          return CityInfoDescript.fromCurrentLocale(name: 'Paris');
         case '+3:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Moscow');
+          return CityInfoDescript.fromCurrentLocale(name: 'Moscow');
         case '+6:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Urumqi');
+          return CityInfoDescript.fromCurrentLocale(name: 'Urumqi');
         case '+8:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Beijing');
+          return CityInfoDescript.fromCurrentLocale(name: 'Beijing');
         case '+9:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Tokyo');
+          return CityInfoDescript.fromCurrentLocale(name: 'Tokyo');
         case '+10:00':
-          return CityInfoDescript.asCurrentLocale(name: 'Sydney');
+          return CityInfoDescript.fromCurrentLocale(name: 'Sydney');
         default:
-          return CityInfoDescript.asCurrentLocale(name: 'New York');
+          return CityInfoDescript.fromCurrentLocale(name: 'New York');
       }
     }();
   }

--- a/lib/data/repositories/misc_info_list_repository.dart
+++ b/lib/data/repositories/misc_info_list_repository.dart
@@ -102,8 +102,9 @@ class MiscInfoListRepositoryImpl extends MiscInfoListRepository {
   Future<WeatherDataItem?> _fetchWeatherData(
       SimpleCityInfo simpleCityInfo) async {
     WeatherDataItem? ret;
-    WeatherItemParamter paramter = WeatherItemParamter();
+    WeatherItemParameter paramter = WeatherItemParameter();
     paramter.cityParam = CityInfo();
+    paramter.cityParam?.name = simpleCityInfo.name;
     paramter.cityParam?.langCode = simpleCityInfo.langCode;
     paramter.cityParam?.countryCode = simpleCityInfo.countryCode;
     Result<WeatherItemRes> result =

--- a/lib/domain/entities/city_select_item.dart
+++ b/lib/domain/entities/city_select_item.dart
@@ -1,5 +1,4 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
-import 'package:ses_novajoj/foundation/data/date_util.dart';
 
 class CitySelectItem {
   List<CityInfo> cityInfos;

--- a/lib/domain/entities/city_select_item.dart
+++ b/lib/domain/entities/city_select_item.dart
@@ -2,11 +2,9 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/date_util.dart';
 
 class CitySelectItem {
-  int id;
-  String string;
+  List<CityInfo> cityInfos;
 
   CitySelectItem({
-    required this.id,
-    required this.string,
+    required this.cityInfos,
   });
 }

--- a/lib/domain/repositories/city_select_repository.dart
+++ b/lib/domain/repositories/city_select_repository.dart
@@ -3,13 +3,12 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/result.dart';
 
 class FetchCitySelectRepoInput {
-  Object id;
-  String string;
+  SimpleCityInfo cityInfo;
 
-  FetchCitySelectRepoInput({required this.id, required this.string});
+  FetchCitySelectRepoInput({required this.cityInfo});
 }
 
 abstract class CitySelectRepository {
-  Future<Result<CitySelectItem>> fetchCitySelect(
+  Future<Result<CitySelectItem>> fetchCityInfos(
       {required FetchCitySelectRepoInput input});
 }

--- a/lib/domain/repositories/city_select_repository.dart
+++ b/lib/domain/repositories/city_select_repository.dart
@@ -3,7 +3,7 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/result.dart';
 
 class FetchCitySelectRepoInput {
-  SimpleCityInfo cityInfo;
+  CityInfo cityInfo;
 
   FetchCitySelectRepoInput({required this.cityInfo});
 }

--- a/lib/domain/usecases/city_select_usecase.dart
+++ b/lib/domain/usecases/city_select_usecase.dart
@@ -2,6 +2,7 @@ import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/repositories/city_select_repository.dart';
 import 'package:ses_novajoj/data/repositories/city_select_repository.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/foundation/data/user_types_descript.dart';
 
 import 'city_select_usecase_output.dart';
 
@@ -13,6 +14,7 @@ class CitySelectUseCaseInput {
 
 abstract class CitySelectUseCase with SimpleBloc<CitySelectUseCaseOutput> {
   void fetchCitySelect({required CitySelectUseCaseInput input});
+  Future<PresentModel> fetchMainCities({required CitySelectUseCaseInput input});
 }
 
 class CitySelectUseCaseImpl extends CitySelectUseCase {
@@ -35,5 +37,15 @@ class CitySelectUseCaseImpl extends CitySelectUseCase {
     }, failure: (error) {
       streamAdd(PresentModel(error: error));
     });
+  }
+
+  @override
+  Future<PresentModel> fetchMainCities(
+      {required CitySelectUseCaseInput input}) async {
+    final list = CityInfoDescript.kMainCities.keys
+        .map((elem) => CityInfoDescript.fromCurrentLocale(name: elem))
+        .toList();
+
+    return PresentModel(model: CitySelectUseCaseModel(list, false));
   }
 }

--- a/lib/domain/usecases/city_select_usecase.dart
+++ b/lib/domain/usecases/city_select_usecase.dart
@@ -6,7 +6,7 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'city_select_usecase_output.dart';
 
 class CitySelectUseCaseInput {
-  SimpleCityInfo cityInfo;
+  CityInfo cityInfo;
   bool dataCleared;
   CitySelectUseCaseInput({required this.cityInfo, this.dataCleared = false});
 }

--- a/lib/domain/usecases/city_select_usecase.dart
+++ b/lib/domain/usecases/city_select_usecase.dart
@@ -6,7 +6,9 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'city_select_usecase_output.dart';
 
 class CitySelectUseCaseInput {
-
+  SimpleCityInfo cityInfo;
+  bool dataCleared;
+  CitySelectUseCaseInput({required this.cityInfo, this.dataCleared = false});
 }
 
 abstract class CitySelectUseCase with SimpleBloc<CitySelectUseCaseOutput> {
@@ -19,13 +21,17 @@ class CitySelectUseCaseImpl extends CitySelectUseCase {
 
   @override
   void fetchCitySelect({required CitySelectUseCaseInput input}) async {
-    final result = await repository.fetchCitySelect(
-        input: FetchCitySelectRepoInput(
-            id: 9999, string: "99999" /* // TODO: dummy code*/));
+    if (input.dataCleared) {
+      streamAdd(
+          PresentModel(model: CitySelectUseCaseModel(<CityInfo>[], true)));
+      return;
+    }
+    final result = await repository.fetchCityInfos(
+        input: FetchCitySelectRepoInput(cityInfo: input.cityInfo));
 
     result.when(success: (value) {
       streamAdd(
-          PresentModel(model: CitySelectUseCaseModel(9999, value.toString() /* // TODO: dummy code*/)));
+          PresentModel(model: CitySelectUseCaseModel(value.cityInfos, false)));
     }, failure: (error) {
       streamAdd(PresentModel(error: error));
     });

--- a/lib/domain/usecases/city_select_usecase_output.dart
+++ b/lib/domain/usecases/city_select_usecase_output.dart
@@ -1,6 +1,6 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 
-abstract class  CitySelectUseCaseOutput {}
+abstract class CitySelectUseCaseOutput {}
 
 class PresentModel extends CitySelectUseCaseOutput {
   final CitySelectUseCaseModel? model;
@@ -9,8 +9,8 @@ class PresentModel extends CitySelectUseCaseOutput {
 }
 
 class CitySelectUseCaseModel {
-  int id;
-  String string;
+  List<CityInfo> cityInfos;
+  bool dataCleared;
 
-  CitySelectUseCaseModel(this.id, this.string);
+  CitySelectUseCaseModel(this.cityInfos, this.dataCleared);
 }

--- a/lib/foundation/data/user_data.dart
+++ b/lib/foundation/data/user_data.dart
@@ -222,6 +222,7 @@ class UserData {
   ///
   /// _saveSimpleCityInfoList
   ///
+  // ignore: unused_element
   void _saveSimpleCityInfoList(
       {required List<SimpleCityInfo> newValues, required String key}) {
     final jsonList = newValues.map((elem) => elem.toJson()).toList();

--- a/lib/foundation/data/user_types.dart
+++ b/lib/foundation/data/user_types.dart
@@ -107,15 +107,20 @@ class UrlSelectInfo {
 class SimpleCityInfo {
   String name;
   String langCode;
+  String state;
   String countryCode;
 
-  SimpleCityInfo({this.name = '', this.langCode = '', this.countryCode = ''});
+  SimpleCityInfo(
+      {this.name = '',
+      this.langCode = '',
+      this.state = '',
+      this.countryCode = ''});
 }
 
 class CityInfo extends SimpleCityInfo {
   int id;
   String zip;
-  String nameDesc; // Name description with current locale.
+  String nameDesc; // Name description with current locale.(same as localName)
   int timezone;
   bool isFavorite;
 
@@ -123,9 +128,10 @@ class CityInfo extends SimpleCityInfo {
       {this.id = 0,
       this.zip = '',
       langCode,
-      name,
+      name = '',
       this.nameDesc = '',
-      countryCode,
+      state = '',
+      countryCode = '',
       this.timezone = 0,
       this.isFavorite = false});
 }

--- a/lib/foundation/data/user_types.dart
+++ b/lib/foundation/data/user_types.dart
@@ -134,6 +134,21 @@ class CityInfo extends SimpleCityInfo {
       countryCode = '',
       this.timezone = 0,
       this.isFavorite = false});
+
+  NovaItemInfo? toItemInfo(
+      {int orderIndex = 0, ServiceType serviceType = ServiceType.none}) {
+    return NovaItemInfo(
+        id: 0,
+        orderIndex: orderIndex,
+        title: nameDesc,
+        urlString: 'http://',
+        createAt: DateTime.now(),
+        serviceType: serviceType);
+  }
+
+  String toCityKey() {
+    return "$name}_$state}_$countryCode";
+  }
 }
 
 enum TemperatureUnit { kelvin, celsius, fahrenheit }

--- a/lib/foundation/data/user_types_descript.dart
+++ b/lib/foundation/data/user_types_descript.dart
@@ -67,19 +67,19 @@ extension CityInfoDescript on CityInfo {
     "Moscow": ["ru", "RU", "莫斯科", "パリ"],
     "Urumqi": ["zh", "CN", "乌鲁木齐", "ウルムチ"],
     "Beijing": ["zh", "CN", "北京", "北京"],
-    "Seoul": ["kr", "RU", "首尔", "ソウル"],
+    "Seoul": ["ko", "KR", "首尔", "ソウル"],
     "Tokyo": ["ja", "JP", "东京", "東京"],
     "Sydney": ["en", "AU", "悉尼", "シドニー"],
     "New York": ["en", "US", "纽约", "ニューヨーク"],
   };
 
-  static CityInfo asCurrentLocale({required String name}) {
+  static CityInfo fromCurrentLocale({required String name}) {
     CityInfo self = CityInfo();
     String locale = Intl.defaultLocale ?? Intl.systemLocale;
     final nameIndex = (String loc) {
       final lang = loc.split('-').first;
       final index = ['en', 'zh', 'ja'].indexOf(lang);
-      return index < 0 ? 0 : index + 2;
+      return index < 0 ? 0 : index + 1;
     }(locale);
 
     final cityItem = kMainCities[name];
@@ -123,7 +123,7 @@ extension CityInfoDescript on CityInfo {
   static isInList({required CityInfo element, required List<CityInfo> list}) {
     final found = list.where((e) =>
         e.name == element.name &&
-        e.state == element.state &&
+        ((e.state != '' && e.state == element.state) || e.state == '') &&
         e.langCode == element.langCode &&
         e.countryCode == element.countryCode);
     return found.isNotEmpty;

--- a/lib/foundation/data/user_types_descript.dart
+++ b/lib/foundation/data/user_types_descript.dart
@@ -27,6 +27,38 @@ extension SimpleUrlInfoDescript on SimpleUrlInfo {
 }
 
 extension SimpleCityInfoDescript on SimpleCityInfo {
+  static SimpleCityInfo fromJson(Map<String, dynamic> json) {
+    SimpleCityInfo self = SimpleCityInfo();
+
+    self.name = json['name'] ?? '';
+    self.state = json['state'] ?? self.name;
+    self.langCode = json['lang_code'] ?? '';
+    self.countryCode = json['country_code'] ?? '';
+    return self;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+
+    data['name'] = name;
+    data['state'] = state;
+    data['lang_code'] = langCode;
+    data['country_code'] = countryCode;
+    return data;
+  }
+
+  static isInList(
+      {required SimpleCityInfo element, required List<SimpleCityInfo> list}) {
+    final found = list.where((e) =>
+        e.name == element.name &&
+        e.state == element.state &&
+        e.langCode == element.langCode &&
+        e.countryCode == element.countryCode);
+    return found.isNotEmpty;
+  }
+}
+
+extension CityInfoDescript on CityInfo {
   static const Map<String, List<String>> kMainCities = {
     "Hawaii": ["en", "US", "夏威夷", "ハワイ"],
     "Sao Paulo": ["pt", "BR", "圣保罗", "サンパロ"],
@@ -41,8 +73,8 @@ extension SimpleCityInfoDescript on SimpleCityInfo {
     "New York": ["en", "US", "纽约", "ニューヨーク"],
   };
 
-  static SimpleCityInfo asCurrentLocale({required String name}) {
-    SimpleCityInfo self = SimpleCityInfo();
+  static CityInfo asCurrentLocale({required String name}) {
+    CityInfo self = CityInfo();
     String locale = Intl.defaultLocale ?? Intl.systemLocale;
     final nameIndex = (String loc) {
       final lang = loc.split('-').first;
@@ -52,9 +84,10 @@ extension SimpleCityInfoDescript on SimpleCityInfo {
 
     final cityItem = kMainCities[name];
     self.name = name;
+    self.nameDesc = name;
     if (cityItem != null) {
       if (nameIndex >= 2) {
-        self.name = cityItem[nameIndex];
+        self.nameDesc = cityItem[nameIndex];
       }
       self.langCode = cityItem[0];
       self.countryCode = cityItem[1];
@@ -62,28 +95,35 @@ extension SimpleCityInfoDescript on SimpleCityInfo {
     return self;
   }
 
-  static SimpleCityInfo fromJson(Map<String, dynamic> json) {
-    SimpleCityInfo self = SimpleCityInfo();
-
+  static CityInfo fromJson(Map<String, dynamic> json) {
+    CityInfo self = CityInfo();
+    self.id = json['id'] ?? 0;
     self.name = json['name'] ?? '';
+    self.nameDesc = json['name_desc'] ?? '';
+    self.state = json['state'] ?? self.name;
     self.langCode = json['lang_code'] ?? '';
     self.countryCode = json['country_code'] ?? '';
+    self.timezone = json['timezone'] ?? 0;
     return self;
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
 
+    data['id'] = id;
     data['name'] = name;
+    data['name_desc'] = nameDesc;
+    data['state'] = state;
     data['lang_code'] = langCode;
     data['country_code'] = countryCode;
+    data['timezone'] = timezone;
     return data;
   }
 
-  static isInList(
-      {required SimpleCityInfo element, required List<SimpleCityInfo> list}) {
+  static isInList({required CityInfo element, required List<CityInfo> list}) {
     final found = list.where((e) =>
         e.name == element.name &&
+        e.state == element.state &&
         e.langCode == element.langCode &&
         e.countryCode == element.countryCode);
     return found.isNotEmpty;

--- a/lib/networking/api/weather_web_api.dart
+++ b/lib/networking/api/weather_web_api.dart
@@ -55,6 +55,29 @@ class WeatherWebApi {
 
     try {
       final response = await BaseApiClient.client.get(Uri.parse(url));
+      if (response.statusCode == HttpStatus.notFound) {
+        // Here get a error as 'City Not Found'
+        // Get city lacation and fetch weather info
+        if (paramter.cityParam != null) {
+          final citySelRes = await getWeatherCities(
+              paramter: CitytItemParameter(cityInfo: paramter.cityParam!));
+          List<dynamic>? cityLoc;
+          citySelRes.when(
+              success: (value) {
+                final cityKey = value.cityInfos?.first.toCityKey();
+                if (cityKey != null) {
+                  cityLoc = value.locations?[cityKey];
+                }
+              },
+              failure: (error) {});
+          // Use cityLoc
+          if (cityLoc != null) {
+            return getWeatherWithLocation(
+                paramter: WeatherItemParameter(
+                    latitude: cityLoc?.first, longitude: cityLoc?.last));
+          }
+        }
+      }
 
       // Convert and return
       if (response.statusCode >= HttpStatus.badRequest) {
@@ -113,7 +136,7 @@ class WeatherWebApi {
 
     final url =
         '$_endpoint/geo/1.0/direct?q=$nameParam&limit=50&appid=$_apiKey';
-    log.info('getCityNameFromLocation $url');
+    log.info('getWeatherCities $url');
 
     try {
       // check network state

--- a/lib/networking/request/city_item_parameter.dart
+++ b/lib/networking/request/city_item_parameter.dart
@@ -1,0 +1,7 @@
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+
+class CitytItemParameter {
+  SimpleCityInfo cityInfo;
+
+  CitytItemParameter({required this.cityInfo});
+}

--- a/lib/networking/request/city_item_parameter.dart
+++ b/lib/networking/request/city_item_parameter.dart
@@ -1,7 +1,7 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 
 class CitytItemParameter {
-  SimpleCityInfo cityInfo;
+  CityInfo cityInfo;
 
   CitytItemParameter({required this.cityInfo});
 }

--- a/lib/networking/request/city_select_item_parameter.dart
+++ b/lib/networking/request/city_select_item_parameter.dart
@@ -1,8 +1,0 @@
-import 'package:ses_novajoj/foundation/data/user_types.dart';
-
-class CitySelectItemParameter {
-  Object itemInfo;
-  String string;
-
-  CitySelectItemParameter({required this.itemInfo, required this.string});
-}

--- a/lib/networking/request/weather_item_parameter.dart
+++ b/lib/networking/request/weather_item_parameter.dart
@@ -2,10 +2,10 @@
 
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 
-class WeatherItemParamter {
+class WeatherItemParameter {
   double latitude;
   double longitude;
   CityInfo? cityParam;
 
-  WeatherItemParamter({this.latitude = 0, this.longitude = 0, this.cityParam});
+  WeatherItemParameter({this.latitude = 0, this.longitude = 0, this.cityParam});
 }

--- a/lib/networking/response/city_select_item_response.dart
+++ b/lib/networking/response/city_select_item_response.dart
@@ -1,11 +1,75 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 
-class CitySelectItemItemRes {
-  Object itemInfo;
-  String string;
+class CitySelectItemRes {
+  List<CityInfo>? cityInfos;
 
-  CitySelectItemItemRes({
-    required this.itemInfo,
-    required this.string,
+  CitySelectItemRes({
+    required this.cityInfos,
   });
+
+  CitySelectItemRes.fromJson(dynamic jsonList) {
+    cityInfos = () {
+      final parsed = jsonList as List?;
+      if (parsed != null) {
+        final list = parsed.map((elem) {
+          CityInfo cityInfo = CityInfo();
+          _findLocalNameAndEtc(cityInfo,
+              nameDic: elem['local_names'],
+              countryCode: elem['country'],
+              defaultName: elem['name']);
+          cityInfo.name = elem['name'];
+          cityInfo.state = elem['state'] ?? elem['name'];
+          cityInfo.countryCode = elem['country'];
+          return cityInfo;
+        }).toList();
+        final keys = list
+            .map((elem) => "${elem.name}_${elem.state}_${elem.countryCode}")
+            .toSet();
+        return list
+            .where((elem) =>
+                keys.remove("${elem.name}_${elem.state}_${elem.countryCode}"))
+            .toList();
+      } else {
+        return <CityInfo>[];
+      }
+    }();
+  }
+
+  void _findLocalNameAndEtc(CityInfo cityInfo,
+      {Map<String, dynamic>? nameDic,
+      String countryCode = '',
+      String defaultName = ''}) {
+    if (nameDic == null) {
+      cityInfo.nameDesc = defaultName;
+      cityInfo.langCode = 'en';
+      return;
+    }
+
+    String nameDesc = defaultName;
+    String langCode = 'en';
+    for (var elem in ['zh', 'ja', 'fr', 'pt', 'ru', 'ko']) {
+      if (elem == 'zh' && ['CN', 'TW'].contains(countryCode)) {
+        nameDesc = nameDic[elem];
+        langCode = 'zh';
+      } else if (elem == 'ja' && countryCode == 'JP') {
+        nameDesc = nameDic[elem];
+        langCode = 'ja';
+      } else if (elem == 'fr' && countryCode == 'FR') {
+        nameDesc = nameDic[elem];
+        langCode = 'fr';
+      } else if (elem == 'pt' && ['BR', 'PT'].contains(countryCode)) {
+        nameDesc = nameDic[elem];
+        langCode = 'pt';
+      } else if (elem == 'ru' && countryCode == 'RU') {
+        nameDesc = nameDic[elem];
+        langCode = 'ru';
+      } else if (elem == 'ko' && countryCode == 'KR') {
+        nameDesc = nameDic[elem];
+        langCode = 'ko';
+      }
+    }
+    cityInfo.nameDesc = nameDesc;
+    cityInfo.langCode = langCode;
+    return;
+  }
 }

--- a/lib/networking/response/city_select_item_response.dart
+++ b/lib/networking/response/city_select_item_response.dart
@@ -1,17 +1,21 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 
 class CitySelectItemRes {
+  Map<String, List<double>>? locations;
   List<CityInfo>? cityInfos;
 
-  CitySelectItemRes({
-    required this.cityInfos,
-  });
+  CitySelectItemRes({required this.cityInfos, this.locations});
+
+  Map<String, List<double>>? _locations;
+  List<CityInfo>? _cityInfos;
 
   CitySelectItemRes.fromJson(dynamic jsonList) {
-    cityInfos = () {
+    _locations ??= {};
+    _cityInfos = () {
       final parsed = jsonList as List?;
       if (parsed != null) {
         final list = parsed.map((elem) {
+          // CityInfo
           CityInfo cityInfo = CityInfo();
           _findLocalNameAndEtc(cityInfo,
               nameDic: elem['local_names'],
@@ -20,19 +24,25 @@ class CitySelectItemRes {
           cityInfo.name = elem['name'];
           cityInfo.state = elem['state'] ?? elem['name'];
           cityInfo.countryCode = elem['country'];
+
+          // LocationInfo
+          _locations?[cityInfo.toCityKey()] = [elem['lat'], elem['lon']];
+
           return cityInfo;
         }).toList();
-        final keys = list
-            .map((elem) => "${elem.name}_${elem.state}_${elem.countryCode}")
-            .toSet();
-        return list
-            .where((elem) =>
-                keys.remove("${elem.name}_${elem.state}_${elem.countryCode}"))
-            .toList();
+
+        final keys = list.map((elem) => elem.toCityKey()).toSet();
+
+        // remove duplicated data
+        // set result
+        return list.where((elem) => keys.remove(elem.toCityKey())).toList();
       } else {
         return <CityInfo>[];
       }
     }();
+
+    cityInfos = _cityInfos;
+    locations = _locations;
   }
 
   void _findLocalNameAndEtc(CityInfo cityInfo,

--- a/lib/scene/city_select/city_select_presenter.dart
+++ b/lib/scene/city_select/city_select_presenter.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/usecases/city_select_usecase.dart';
@@ -12,13 +14,15 @@ class CitySelectPresenterInput {
   Object? completeHandler;
   ServiceType serviceType;
   int order;
+  bool dataCleared;
 
   CitySelectPresenterInput(
       {this.appBarTitle = '',
       this.serviceType = ServiceType.none,
       this.order = 0,
       this.selectedCityInfo,
-      this.completeHandler});
+      this.completeHandler,
+      this.dataCleared = false});
 }
 
 abstract class CitySelectPresenter with SimpleBloc<CitySelectPresenterOutput> {
@@ -31,9 +35,35 @@ class CitySelectPresenterImpl extends CitySelectPresenter {
   final CitySelectUseCase useCase;
   final CitySelectRouter router;
 
+  late StreamSubscription<CitySelectUseCaseOutput> _streamSubscription;
+  bool _isRefreshed = false;
+
   CitySelectPresenterImpl({required this.router})
       : useCase = CitySelectUseCaseImpl() {
-    useCase.stream.listen((event) {
+    _streamSubscription = _addStreamListener();
+  }
+
+  @override
+  void eventViewReady({required CitySelectPresenterInput input}) async {
+    if (_isRefreshed) {
+      await _streamSubscription.cancel();
+      _streamSubscription = _addStreamListener();
+    } else {
+      _isRefreshed = true;
+    }
+    useCase.fetchCitySelect(
+        input: CitySelectUseCaseInput(
+            cityInfo: input.selectedCityInfo!, dataCleared: input.dataCleared));
+  }
+
+  @override
+  bool eventSelectingCityInfo(Object context,
+      {required CitySelectPresenterInput input}) {
+    return true;
+  }
+
+  StreamSubscription<CitySelectUseCaseOutput> _addStreamListener() {
+    return useCase.stream.listen((event) {
       if (event is PresentModel) {
         if (event.error == null) {
           streamAdd(ShowCitySelectPageModel(
@@ -43,16 +73,5 @@ class CitySelectPresenterImpl extends CitySelectPresenter {
         }
       }
     });
-  }
-
-  @override
-  void eventViewReady({required CitySelectPresenterInput input}) {
-    useCase.fetchCitySelect(input: CitySelectUseCaseInput());
-  }
-
-  @override
-  bool eventSelectingCityInfo(Object context,
-      {required CitySelectPresenterInput input}) {
-    return true;
   }
 }

--- a/lib/scene/city_select/city_select_presenter.dart
+++ b/lib/scene/city_select/city_select_presenter.dart
@@ -30,6 +30,8 @@ abstract class CitySelectPresenter with SimpleBloc<CitySelectPresenterOutput> {
   void eventViewReady({required CitySelectPresenterInput input});
   bool eventSelectingCityInfo(Object context,
       {required CitySelectPresenterInput input});
+  Future<ShowCitySelectPageModel> eventSelectMainCities(
+      {required CitySelectPresenterInput input});
 }
 
 class CitySelectPresenterImpl extends CitySelectPresenter {
@@ -52,9 +54,12 @@ class CitySelectPresenterImpl extends CitySelectPresenter {
     } else {
       _isRefreshed = true;
     }
-    useCase.fetchCitySelect(
-        input: CitySelectUseCaseInput(
-            cityInfo: input.selectedCityInfo!, dataCleared: input.dataCleared));
+    Future.delayed(const Duration(seconds: 1), () {
+      useCase.fetchCitySelect(
+          input: CitySelectUseCaseInput(
+              cityInfo: input.selectedCityInfo!,
+              dataCleared: input.dataCleared));
+    });
   }
 
   @override
@@ -74,6 +79,14 @@ class CitySelectPresenterImpl extends CitySelectPresenter {
           completeHandler: input.completeHandler);
     }
     return saved;
+  }
+
+  @override
+  Future<ShowCitySelectPageModel> eventSelectMainCities(
+      {required CitySelectPresenterInput input}) async {
+    final ret = await useCase.fetchMainCities(
+        input: CitySelectUseCaseInput(cityInfo: CityInfo()));
+    return ShowCitySelectPageModel(viewModel: CitySelectViewModel(ret.model!));
   }
 
   StreamSubscription<CitySelectUseCaseOutput> _addStreamListener() {

--- a/lib/scene/city_select/city_select_presenter.dart
+++ b/lib/scene/city_select/city_select_presenter.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ses_novajoj/foundation/data/user_data.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/usecases/city_select_usecase.dart';
@@ -10,7 +11,7 @@ import 'city_select_router.dart';
 
 class CitySelectPresenterInput {
   String appBarTitle;
-  SimpleCityInfo? selectedCityInfo;
+  CityInfo? selectedCityInfo;
   Object? completeHandler;
   ServiceType serviceType;
   int order;
@@ -59,7 +60,20 @@ class CitySelectPresenterImpl extends CitySelectPresenter {
   @override
   bool eventSelectingCityInfo(Object context,
       {required CitySelectPresenterInput input}) {
-    return true;
+    // save the selected url info
+    bool saved = UserData().saveUserInfoList(
+        newValue: input.selectedCityInfo,
+        order: input.order,
+        serviceType: input.serviceType);
+
+    // navigate the target as web page if exists
+    if (saved) {
+      router.gotoMiscListPage(context,
+          itemInfo: input.selectedCityInfo
+              ?.toItemInfo(serviceType: input.serviceType),
+          completeHandler: input.completeHandler);
+    }
+    return saved;
   }
 
   StreamSubscription<CitySelectUseCaseOutput> _addStreamListener() {

--- a/lib/scene/city_select/city_select_presenter_output.dart
+++ b/lib/scene/city_select/city_select_presenter_output.dart
@@ -10,11 +10,10 @@ class ShowCitySelectPageModel extends CitySelectPresenterOutput {
 }
 
 class CitySelectViewModel {
-  int id; 
+  List<CityInfo> cityInfos;
+  bool dataCleared;
 
   CitySelectViewModel(CitySelectUseCaseModel model)
-      : id = model.id/*,
-       name = model.name,
-      ...
-      */;
+      : cityInfos = model.cityInfos,
+        dataCleared = model.dataCleared;
 }

--- a/lib/scene/city_select/city_select_router.dart
+++ b/lib/scene/city_select/city_select_router.dart
@@ -13,6 +13,5 @@ class CitySelectRouterImpl extends CitySelectRouter {
       {Object? itemInfo, Object? completeHandler}) {
     BuildContext context_ = context as BuildContext;
     Navigator.of(context_).pop();
-    Navigator.of(context_).pop();
   }
 }

--- a/lib/scene/city_select/city_select_router.dart
+++ b/lib/scene/city_select/city_select_router.dart
@@ -1,13 +1,18 @@
+import 'package:flutter/material.dart';
+
 abstract class CitySelectRouter {
-  //void gotoTop(Object context);
+  void gotoMiscListPage(Object context,
+      {Object? itemInfo, Object? completeHandler});
 }
 
 class CitySelectRouterImpl extends CitySelectRouter {
   CitySelectRouterImpl();
 
-  // @override
-  // void gotoTop(Object context) {
-  //   log.info('gotoTop');
-  //   Navigator.pushNamed(context as BuildContext, ScreenRouteName.tabs.name);
-  // }
+  @override
+  void gotoMiscListPage(Object context,
+      {Object? itemInfo, Object? completeHandler}) {
+    BuildContext context_ = context as BuildContext;
+    Navigator.of(context_).pop();
+    Navigator.of(context_).pop();
+  }
 }

--- a/lib/scene/foundation/data/weather_util.dart
+++ b/lib/scene/foundation/data/weather_util.dart
@@ -164,7 +164,7 @@ class WeatherUtil {
         case 500:
           return 'light rain,小雨,小雨';
         case 501:
-          return 'moderate rain,雨，適度な雨';
+          return 'moderate rain,雨,適度な雨';
         case 502:
           return 'heavy intensity rain,强降雨,重い強度の雨';
         case 503:

--- a/lib/scene/misc_info_list/misc_info_list_page.dart
+++ b/lib/scene/misc_info_list/misc_info_list_page.dart
@@ -85,12 +85,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
     ];
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceMyTime ?? '',
-      rowTitles: <Widget>[
-        _toTextWidget(rowTitleStrings[0]),
-        _toTextWidget(rowTitleStrings[1]),
-        _toTextWidget(rowTitleStrings[2]),
-        _toTextWidget(rowTitleStrings[3]),
-      ],
+      rowTitles: rowTitleStrings.map((elem) => _buildTextWidget(elem)).toList(),
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(
@@ -111,12 +106,12 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
       {List<MiscInfoListViewModel>? viewModelList}) {
     final rowTitles = viewModelList
         ?.where((element) => element.itemInfo.serviceType == ServiceType.audio)
-        .map((element) => _toTextWidget(element.itemInfo.title))
+        .map((element) => _buildTextWidget(element.itemInfo.title))
         .toList();
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceOnline ?? '',
       rowTitles: rowTitles ?? [],
-      otherTitle: _toTextWidget(UseL10n.of(context)?.infoServiceItemOther),
+      otherTitle: _buildTextWidget(UseL10n.of(context)?.infoServiceItemOther),
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(
@@ -154,8 +149,8 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
 
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceWeather ?? '',
-      rowTitles: _toRowWeatherWidgets(weatherInfos),
-      otherTitle: _toTextWidget(UseL10n.of(context)?.infoServiceItemOther),
+      rowTitles: _buildRowWeatherWidgets(weatherInfos),
+      otherTitle: _buildTextWidget(UseL10n.of(context)?.infoServiceItemOther),
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(
@@ -193,7 +188,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceFavorites ?? '',
       rowTitles: const <Widget>[],
-      otherTitle: _toTextWidget(UseL10n.of(context)?.infoServiceItemOther),
+      otherTitle: _buildTextWidget(UseL10n.of(context)?.infoServiceItemOther),
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(
@@ -212,7 +207,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
       rowTitles: const <Widget>[],
-      otherTitle: _toTextWidget(UseL10n.of(context)?.infoServiceItemOther),
+      otherTitle: _buildTextWidget(UseL10n.of(context)?.infoServiceItemOther),
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(
@@ -226,20 +221,20 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
     );
   }
 
-  Widget _toTextWidget(String? str) {
+  Widget _buildTextWidget(String? str) {
     return Text(
       str ?? '',
       style: const TextStyle(color: Color(0xFF8D918D)),
     );
   }
 
-  List<Widget> _toRowWeatherWidgets(List<WeatherInfo?>? infos) {
+  List<Widget> _buildRowWeatherWidgets(List<WeatherInfo?>? infos) {
     return infos
             ?.map((info) => Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Text(
-                      info?.city?.name ?? '',
+                      info?.city?.nameDesc ?? '',
                       style: const TextStyle(color: Color(0xFF8D918D)),
                     ),
                     const SizedBox(width: 10),
@@ -249,7 +244,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
                     ),
                     const SizedBox(width: 10),
                     Container(
-                        padding: const EdgeInsets.only(bottom: 8),
+                        padding: const EdgeInsets.only(bottom: 4),
                         child: Icon(
                           WeatherUtil().getIconData(info?.iconCode),
                           color: Colors.black45,

--- a/lib/scene/misc_info_list/misc_info_list_presenter.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter.dart
@@ -63,7 +63,7 @@ class MiscInfoListPresenterImpl extends MiscInfoListPresenter {
     void removeAction() {
       UserData().saveUserInfoList(
           newValue: input.serviceType == ServiceType.weather
-              ? SimpleCityInfo()
+              ? CityInfo()
               : SimpleUrlInfo(),
           order: input.itemIndex,
           allowsRemove: true,
@@ -72,12 +72,17 @@ class MiscInfoListPresenterImpl extends MiscInfoListPresenter {
 
     NovaItemInfo? itemInfo;
     if (itemInfos == null || itemInfos.isEmpty || input.itemIndex == -1) {
-      itemInfo = SimpleUrlInfo().toItemInfo(
-          orderIndex: input.itemIndex, serviceType: input.serviceType);
+      if (input.serviceType == ServiceType.weather) {
+        itemInfo = CityInfo().toItemInfo(
+            orderIndex: input.itemIndex, serviceType: input.serviceType);
+      } else {
+        itemInfo = SimpleUrlInfo().toItemInfo(
+            orderIndex: input.itemIndex, serviceType: input.serviceType);
+      }
     } else {
       itemInfo = itemInfos.first.itemInfo;
     }
-    if (itemInfo?.urlString.isEmpty ?? true) {
+    if (input.itemIndex == -1) {
       if (input.serviceType == ServiceType.weather) {
         router.gotoCitySelectPage(context,
             appBarTitle: input.appBarTitle,

--- a/lib/scene/misc_info_list/weather_info_overlay.dart
+++ b/lib/scene/misc_info_list/weather_info_overlay.dart
@@ -112,56 +112,74 @@ class WeatherInfoOverlayState extends State<WeatherInfoOverlay>
   Widget _buildWeatherContentArea(BuildContext context,
       {WeatherInfo? itemValue}) {
     final double screenWidth = MediaQuery.of(context).size.width;
-
+    final leftSideWidth = () {
+      if (screenWidth <= 280) return 110.0;
+      if (screenWidth <= 360) return 150.0;
+      if (screenWidth <= 420) {
+        return 210.0;
+      } else {
+        return 250.0;
+      }
+    }();
     return SizedBox(
-        width: screenWidth - 60,
+        width: screenWidth - 40,
         child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            const Spacer(),
             Container(
-                constraints: BoxConstraints(
-                    minWidth: 80,
-                    maxWidth: () {
-                      if (screenWidth <= 280) return 110.0;
-                      if (screenWidth <= 360) return 150.0;
-                      if (screenWidth <= 420) {
-                        return 180.0;
-                      } else {
-                        return 250.0;
-                      }
-                    }()),
+                constraints:
+                    BoxConstraints(minWidth: 80, maxWidth: leftSideWidth),
                 child: GestureDetector(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.all(8),
-                        child: Text('${itemValue?.city?.name}',
-                            softWrap: false,
-                            overflow: TextOverflow.ellipsis,
-                            style: _createTextStyle(
-                                fontSize: 19.0, color: Colors.black54)),
-                      ),
-                      Text('${itemValue?.getWeatherDesc()}',
-                          softWrap: false,
-                          overflow: TextOverflow.ellipsis,
-                          style: _createTextStyle(
-                              fontSize: 11.0, color: Colors.black54)),
-                    ],
-                  ),
+                  child: Padding(
+                      padding: const EdgeInsets.only(top: 10, bottom: 0),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text('${itemValue?.city?.nameDesc}',
+                              softWrap: true,
+                              overflow: TextOverflow.ellipsis,
+                              style: _createTextStyle(
+                                  fontSize: 19.0, color: Colors.black54)),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              const Spacer(),
+                              itemValue?.city?.state.isEmpty ?? false
+                                  ? const SizedBox()
+                                  : Container(
+                                      padding: const EdgeInsets.only(
+                                          top: 6, right: 8),
+                                      alignment: Alignment.center,
+                                      width: leftSideWidth - 20,
+                                      child: Text(
+                                          '${itemValue?.city?.state}, ${itemValue?.city?.countryCode}',
+                                          softWrap: true,
+                                          overflow: TextOverflow.clip,
+                                          style: _createTextStyle(
+                                              fontSize: 10.0,
+                                              color: Colors.black54)),
+                                    ),
+                            ],
+                          ),
+                          Text('${itemValue?.getWeatherDesc()}',
+                              softWrap: false,
+                              overflow: TextOverflow.ellipsis,
+                              style: _createTextStyle(
+                                  fontSize: 14.0, color: Colors.black54)),
+                        ],
+                      )),
                   onTap: () {
                     // setState(() {
                     //   widget.onCellEditing?.call();
                     // });
                   },
                 )),
-            const Spacer(),
             Text('${itemValue?.temperature?.as(widget.temprtUnit).round()}°',
-                style: _createTextStyle(fontSize: 40.0, color: Colors.black54)),
+                style: _createTextStyle(fontSize: 32.0, color: Colors.black54)),
             const Spacer(),
             Padding(
-                padding: const EdgeInsets.only(bottom: 15),
+                padding: const EdgeInsets.only(bottom: 5),
                 child: Icon(
                   itemValue?.getIconData(),
                   color: Colors.black54,
@@ -169,7 +187,7 @@ class WeatherInfoOverlayState extends State<WeatherInfoOverlay>
                 )),
             const Spacer(),
             Container(
-                width: 40,
+                width: 32,
                 padding: const EdgeInsets.symmetric(vertical: 5.0),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -184,7 +202,6 @@ class WeatherInfoOverlayState extends State<WeatherInfoOverlay>
                             fontSize: 16.0, color: Colors.black54)),
                   ],
                 )),
-            const Spacer(),
           ],
         ));
   }


### PR DESCRIPTION
city select page (phase-6_1)

General:

- add 'getWeatherCity' to fetch cityinfo (name, localName, state, country) of a given city / place.
- refactoring classes based on viper architecture.

City Select Page:

- adjust page layout codes according to bloc instead of future.
- change [search flag] to bloc due to bad state error.

city select page (phase-6_2)

General:

- save the selected city data on `city select`
- fix `getWeatherData` api when failed to fetch weather info using city name
- fix `fetchMiscInfoList` repository of `misc info list`

City Select Page:

- refactoring and reshape codes

Misc info list Page:

- adjust 'weather info' overlay layout
- add country / state info on 'weather info' overlay

city select page (phase-6_3)

General:

- change common method name in CityInfoDescription

City Select Page:

- add `main cities` displaying and selecting event
- here a bug: cannot select a city after cancel the modal
