### PR TITLE
sn-041_add_historio_page_layout

### DIFF
--- a/lib/data/repositories/historio_repository.dart
+++ b/lib/data/repositories/historio_repository.dart
@@ -1,0 +1,31 @@
+import 'package:ses_novajoj/foundation/data/result.dart';
+//import 'package:ses_novajoj/networking/api/my_web_api.dart';
+// import 'package:ses_novajoj/networking/response/historio_item_response.dart';
+// import 'package:ses_novajoj/networking/request/historio_item_parameter.dart';
+import 'package:ses_novajoj/domain/entities/historio_item.dart';
+import 'package:ses_novajoj/domain/repositories/historio_repository.dart';
+
+/// TODO: This is dummy Web API class.
+/// You should  web api class is defined in its dart file, like `my_web_api.dart`
+class MyWebApi {}
+
+class HistorioRepositoryImpl extends HistorioRepository {
+  final MyWebApi _api;
+
+  // sigleton
+  static final HistorioRepositoryImpl _instance =
+      HistorioRepositoryImpl._internal();
+  HistorioRepositoryImpl._internal() : _api = MyWebApi();
+  factory HistorioRepositoryImpl() => _instance;
+
+  @override
+  Future<Result<HistorioItem>> fetchHistorio(
+
+      {required FetchHistorioRepoInput input}) async {
+    Result<HistorioItem> result =
+        Result.success(data: HistorioItem(id: 9999, string: "9999"));    // TODO: call api
+
+    // TODO: change api result for `Historio' repository
+    return result;
+  }
+}

--- a/lib/domain/entities/historio_item.dart
+++ b/lib/domain/entities/historio_item.dart
@@ -1,0 +1,12 @@
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/foundation/data/date_util.dart';
+
+class HistorioItem {
+  int id;
+  String string;
+
+  HistorioItem({
+    required this.id,
+    required this.string,
+  });
+}

--- a/lib/domain/repositories/historio_repository.dart
+++ b/lib/domain/repositories/historio_repository.dart
@@ -1,0 +1,15 @@
+import 'package:ses_novajoj/domain/entities/historio_item.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/foundation/data/result.dart';
+
+class FetchHistorioRepoInput {
+  Object id;
+  String string;
+
+  FetchHistorioRepoInput({required this.id, required this.string});
+}
+
+abstract class HistorioRepository {
+  Future<Result<HistorioItem>> fetchHistorio(
+      {required FetchHistorioRepoInput input});
+}

--- a/lib/domain/usecases/historio_usecase.dart
+++ b/lib/domain/usecases/historio_usecase.dart
@@ -1,0 +1,33 @@
+import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
+import 'package:ses_novajoj/domain/repositories/historio_repository.dart';
+import 'package:ses_novajoj/data/repositories/historio_repository.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+
+import 'historio_usecase_output.dart';
+
+class HistorioUseCaseInput {
+
+}
+
+abstract class HistorioUseCase with SimpleBloc<HistorioUseCaseOutput> {
+  void fetchHistorio({required HistorioUseCaseInput input});
+}
+
+class HistorioUseCaseImpl extends HistorioUseCase {
+  final HistorioRepositoryImpl repository;
+  HistorioUseCaseImpl() : repository = HistorioRepositoryImpl();
+
+  @override
+  void fetchHistorio({required HistorioUseCaseInput input}) async {
+    final result = await repository.fetchHistorio(
+        input: FetchHistorioRepoInput(
+            id: 9999, string: "99999" /* // TODO: dummy code*/));
+
+    result.when(success: (value) {
+      streamAdd(
+          PresentModel(model: HistorioUseCaseModel(9999, value.toString() /* // TODO: dummy code*/)));
+    }, failure: (error) {
+      streamAdd(PresentModel(error: error));
+    });
+  }
+}

--- a/lib/domain/usecases/historio_usecase_output.dart
+++ b/lib/domain/usecases/historio_usecase_output.dart
@@ -1,0 +1,16 @@
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+
+abstract class  HistorioUseCaseOutput {}
+
+class PresentModel extends HistorioUseCaseOutput {
+  final HistorioUseCaseModel? model;
+  final AppError? error;
+  PresentModel({this.model, this.error});
+}
+
+class HistorioUseCaseModel {
+  int id;
+  String string;
+
+  HistorioUseCaseModel(this.id, this.string);
+}

--- a/lib/foundation/data/user_types.dart
+++ b/lib/foundation/data/user_types.dart
@@ -17,8 +17,8 @@ enum ServiceType {
   time,
   audio,
   weather,
-  favorite,
-  history,
+  // favorite,
+  // history,
 }
 
 class Comment {
@@ -72,6 +72,21 @@ class NovaItemInfo {
       this.isNew = false,
       this.children,
       this.weatherInfo});
+}
+
+class HistorioInfo {
+  int id;
+  DateTime createdAt;
+  String category;
+  NovaItemInfo itemInfo;
+  String? htmlText;
+
+  HistorioInfo(
+      {required this.id,
+      required this.createdAt,
+      this.category = '',
+      required this.itemInfo,
+      this.htmlText});
 }
 
 class SimpleUrlInfo {

--- a/lib/foundation/data/user_types_descript.dart
+++ b/lib/foundation/data/user_types_descript.dart
@@ -1,4 +1,5 @@
 import 'user_types.dart';
+import 'date_util.dart';
 import 'package:intl/intl.dart';
 
 extension SimpleUrlInfoDescript on SimpleUrlInfo {
@@ -130,7 +131,13 @@ extension CityInfoDescript on CityInfo {
   }
 }
 
-extension ServiceTypeDescriot on ServiceType {
+extension HistorioInfoDescript on HistorioInfo {
+  String get createdAtText {
+    return DateUtil().getDateString(date: createdAt, format: 'M/d (E)');
+  }
+}
+
+extension ServiceTypeDescript on ServiceType {
   static ServiceType fromString(String string) {
     return ServiceType.values.firstWhere((element) => element.name == string);
   }
@@ -140,8 +147,6 @@ extension ServiceTypeDescriot on ServiceType {
       case ServiceType.time:
       case ServiceType.audio:
       case ServiceType.weather:
-      case ServiceType.favorite:
-      case ServiceType.history:
         return toString().split(".").last;
       default:
         return '';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -103,6 +103,7 @@
   "infoServiceFavorites":"Favorites",
   "infoServiceHistory":"Historio",
   "infoServiceItemOther":"Other...",
+  "infoServiceItemMore":"More...",
   "infoServicelistSelectHintMessage":"Select a site name and url as Web site.",
   "infoServicelistInputHintMessage":"If there is no site selected in the above list, directly enter your own Web site name and its URL.",
   "infoServicelistInputOther":"Other",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -103,6 +103,7 @@
     "infoServiceFavorites":"收藏",
     "infoServiceHistory":"查看历史",
     "infoServiceItemOther":"其他...",
+    "infoServiceItemMore":"更多...",
     "infoServicelistSelectHintMessage":"请从一览选择自己的Web服务站点。",
     "infoServicelistInputHintMessage":"如果上面一览没有选择的对象，则直接输入自己的Web服务站点及其网址。",
     "infoServicelistInputOther":"另外指定",

--- a/lib/networking/request/historio_item_parameter.dart
+++ b/lib/networking/request/historio_item_parameter.dart
@@ -1,0 +1,8 @@
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+
+class HistorioItemParameter {
+  Object itemInfo;
+  String string;
+
+  HistorioItemParameter({required this.itemInfo, required this.string});
+}

--- a/lib/networking/response/historio_item_response.dart
+++ b/lib/networking/response/historio_item_response.dart
@@ -1,0 +1,11 @@
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+
+class HistorioItemItemRes {
+  Object itemInfo;
+  String string;
+
+  HistorioItemItemRes({
+    required this.itemInfo,
+    required this.string,
+  });
+}

--- a/lib/networking/response/misc_info_select_item_response.dart
+++ b/lib/networking/response/misc_info_select_item_response.dart
@@ -10,7 +10,7 @@ class MiscInfoSelectItemItemRes {
     int id = json['id'];
     int order = json['order'];
     ServiceType serviceType =
-        ServiceTypeDescriot.fromString(json['service_type'] ?? 'none');
+        ServiceTypeDescript.fromString(json['service_type'] ?? 'none');
     final urlItemList = (List<dynamic>? inList) {
       return inList != null
           ? inList

--- a/lib/scene/city_select/city_select_page.dart
+++ b/lib/scene/city_select/city_select_page.dart
@@ -368,6 +368,7 @@ class _CitySelectPageState extends State<CitySelectPage> {
             ),
           );
         }).whenComplete(() {
+      _cityNameDesc = _itemInfo?.weatherInfo?.city?.nameDesc;
       if (_cityNameEditController.text !=
           (_itemInfo?.weatherInfo?.city?.name ?? '')) {
         _cityNameDesc = '';

--- a/lib/scene/foundation/page/page_parameter.dart
+++ b/lib/scene/foundation/page/page_parameter.dart
@@ -10,9 +10,11 @@ enum CitySelectParamKeys { appBarTitle, itemInfo, sourceRoute }
 
 enum MiscInfoSelectParamKeys { appBarTitle, itemInfo }
 
-enum WebPageParamKeys { appBarTitle, itemInfo, menuItems, menuActions }
+enum HistorioParamKeys { appBarTitle, itemInfo, sourceRoute }
 
 enum WeeklyReportParamKeys { appBarTitle, itemInfo, menuItems, menuActions }
+
+enum WebPageParamKeys { appBarTitle, itemInfo, menuItems, menuActions }
 
 enum DetailMenuItem {
   openOriginal,

--- a/lib/scene/foundation/page/screen_route_enums.dart
+++ b/lib/scene/foundation/page/screen_route_enums.dart
@@ -14,6 +14,7 @@ enum ScreenRouteName {
   citySelect,
   miscInfoSelect,
   weeklyReport,
+  historio,
   webPage,
 }
 
@@ -48,6 +49,8 @@ extension ScreenRouteNameSummary on ScreenRouteName {
         return 'miscInfoSelect';
       case ScreenRouteName.weeklyReport:
         return 'weeklyReport';
+      case ScreenRouteName.historio:
+        return 'historio';
       case ScreenRouteName.webPage:
         return 'webPage';
       default:

--- a/lib/scene/foundation/screen_route_manager.dart
+++ b/lib/scene/foundation/screen_route_manager.dart
@@ -11,6 +11,7 @@ import 'package:ses_novajoj/scene/bbs_select_list/bbs_select_list_page_builder.d
 import 'package:ses_novajoj/scene/city_select/city_select_page_builder.dart';
 import 'package:ses_novajoj/scene/misc_info_select/misc_info_select_page_builder.dart';
 import 'package:ses_novajoj/scene/weekly_report/weekly_report_page_builder.dart';
+import 'package:ses_novajoj/scene/historio/historio_page_builder.dart';
 import 'package:ses_novajoj/scene/root/web_page_builder.dart';
 
 class ScreenRouteManager {
@@ -53,6 +54,9 @@ class ScreenRouteManager {
       case ScreenRouteName.weeklyReport:
         return MaterialPageRoute(
             builder: (_) => WeeklyReportPageBuilder().page, settings: settings);
+      case ScreenRouteName.historio:
+        return MaterialPageRoute(
+            builder: (_) => HistorioPageBuilder().page, settings: settings);
       case ScreenRouteName.webPage:
         return MaterialPageRoute(
             builder: (_) => WebPageBuilder().page, settings: settings);

--- a/lib/scene/historio/historio_page.dart
+++ b/lib/scene/historio/historio_page.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/domain/foundation/bloc/bloc_provider.dart';
+import 'package:ses_novajoj/scene/foundation/use_l10n.dart';
+import 'package:ses_novajoj/scene/foundation/color_def.dart';
+import 'package:ses_novajoj/scene/foundation/page/page_parameter.dart';
+import 'package:ses_novajoj/scene/historio/historio_presenter.dart';
+import 'package:ses_novajoj/scene/historio/historio_presenter_output.dart';
+import 'package:ses_novajoj/scene/widgets/historio_cell.dart';
+
+class HistorioPage extends StatefulWidget {
+  final HistorioPresenter presenter;
+  const HistorioPage({Key? key, required this.presenter}) : super(key: key);
+
+  @override
+  _HistorioPageState createState() => _HistorioPageState();
+}
+
+class _HistorioPageState extends State<HistorioPage> {
+  bool _pageLoadIsFirst = true;
+
+  late String _appBarTitle;
+  Map? _parameters;
+  NovaItemInfo? _itemInfo;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        //title: Text(_appBarTitle),
+        backgroundColor: ColorDef.appBarBackColor,
+        centerTitle: true,
+      ),
+      body: FutureBuilder<List<HistorioInfo>>(
+          future: () {}(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return Center(
+                  child: CircularProgressIndicator(
+                      color: Colors.amber, backgroundColor: Colors.grey[850]));
+            }
+            final data = snapshot.data;
+            if (data != null) {
+              return ListView.builder(
+                  itemCount: data.length,
+                  itemBuilder: (context, index) => HistorioCell(
+                      viewModel: data[index],
+                      onCellSelecting: (selIndex) {
+                        /*widget.presenter.eventSelectDetail(context,
+                            appBarTitle: _selectedAppBarTitle,
+                            itemInfo: data.viewModelList![selIndex].itemInfo,
+                            completeHandler: () {
+                        });*/
+                      },
+                      onThumbnailShowing: (thumbIndex) async {
+                        if (data[thumbIndex]
+                            .itemInfo
+                            .thunnailUrlString
+                            .isNotEmpty) {
+                          return data[thumbIndex].itemInfo.thunnailUrlString;
+                        }
+                        final retUrl =
+                            'http://www.google.com/'; /*await widget.presenter
+                            .eventFetchThumbnail(
+                                targetUrl: data.viewModelList![thumbIndex]
+                                    .itemInfo.urlString);*/
+                        data[thumbIndex].itemInfo.thunnailUrlString = retUrl;
+                        return retUrl;
+                      },
+                      index: index));
+            } else {
+              return const Text('No data!');
+            }
+          }),
+    );
+  }
+
+  void _parseRouteParameter() {
+    if (!_pageLoadIsFirst) {
+      return;
+    }
+    //
+    // get page paratmers via ModalRoute
+    //
+    _parameters = ModalRoute.of(context)?.settings.arguments as Map?;
+    _appBarTitle = _parameters?[HistorioParamKeys.appBarTitle] as String? ?? '';
+    _itemInfo = _parameters?[HistorioParamKeys.itemInfo] as NovaItemInfo?;
+
+    //
+    // FA
+    //
+    // if ((_parameters?[TopDetailParamKeys.source] as String? ?? '') ==
+    //     ScreenRouteName.tabs.name) {
+    //   // send viewEvent
+    //   FirebaseUtil().sendViewEvent(route: AnalyticsRoute.bbsDetail);
+    // }
+
+    // fetch data
+    //_loadData(itemInfo: _itemInfo);
+
+    // set  _pageLoadIsFirst -> false;
+    _pageLoadIsFirst = false;
+  }
+}

--- a/lib/scene/historio/historio_page_builder.dart
+++ b/lib/scene/historio/historio_page_builder.dart
@@ -1,0 +1,17 @@
+import 'historio_page.dart';
+import 'historio_presenter.dart';
+import 'historio_router.dart';
+
+class HistorioPageBuilder {
+  final HistorioPage page;
+
+  HistorioPageBuilder._(this.page);
+
+  factory HistorioPageBuilder() {
+    final router = HistorioRouterImpl();
+    final presenter = HistorioPresenterImpl(router: router);
+    final page = HistorioPage(presenter: presenter);
+
+    return HistorioPageBuilder._(page);
+  }
+}

--- a/lib/scene/historio/historio_presenter.dart
+++ b/lib/scene/historio/historio_presenter.dart
@@ -1,0 +1,39 @@
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
+import 'package:ses_novajoj/domain/usecases/historio_usecase.dart';
+import 'package:ses_novajoj/domain/usecases/historio_usecase_output.dart';
+import 'historio_presenter_output.dart';
+
+import 'historio_router.dart';
+
+class HistorioPresenterInput {
+
+}
+
+abstract class HistorioPresenter with SimpleBloc<HistorioPresenterOutput> {
+  void eventViewReady({required HistorioPresenterInput input});
+}
+
+class HistorioPresenterImpl extends HistorioPresenter {
+  final HistorioUseCase useCase;
+  final HistorioRouter router;
+
+  HistorioPresenterImpl({required this.router})
+      : useCase = HistorioUseCaseImpl() {
+    useCase.stream.listen((event) {
+      if (event is PresentModel) {
+        if (event.error == null) {
+          streamAdd(ShowHistorioPageModel(
+              viewModel: HistorioViewModel(event.model!)));
+        } else {
+          streamAdd(ShowHistorioPageModel(error: event.error));
+        }
+      }
+    });
+  }
+
+  @override
+  void eventViewReady({required HistorioPresenterInput input}) {
+    useCase.fetchHistorio(input: HistorioUseCaseInput());
+  }
+}

--- a/lib/scene/historio/historio_presenter_output.dart
+++ b/lib/scene/historio/historio_presenter_output.dart
@@ -1,0 +1,20 @@
+import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/foundation/data/user_types_descript.dart';
+//import 'package:ses_novajoj/domain/usecases/historio_usecase_output.dart';
+
+abstract class HistorioPresenterOutput {}
+
+class ShowHistorioPageModel extends HistorioPresenterOutput {
+  final HistorioViewModel? viewModel;
+  final AppError? error;
+  ShowHistorioPageModel({this.viewModel, this.error});
+}
+
+class HistorioViewModel {
+  HistorioInfo hisInfo;
+  String createdAtText;
+
+  HistorioViewModel(dynamic model)
+      : hisInfo = model.hisInfo,
+        createdAtText = (model.hisInfo as HistorioInfo?)?.createdAtText ?? '';
+}

--- a/lib/scene/historio/historio_router.dart
+++ b/lib/scene/historio/historio_router.dart
@@ -1,0 +1,13 @@
+abstract class HistorioRouter {
+  //void gotoTop(Object context);
+}
+
+class HistorioRouterImpl extends HistorioRouter {
+  HistorioRouterImpl();
+
+  // @override
+  // void gotoTop(Object context) {
+  //   log.info('gotoTop');
+  //   Navigator.pushNamed(context as BuildContext, ScreenRouteName.tabs.name);
+  // }
+}

--- a/lib/scene/misc_info_list/misc_info_list_page.dart
+++ b/lib/scene/misc_info_list/misc_info_list_page.dart
@@ -7,6 +7,7 @@ import 'package:ses_novajoj/scene/misc_info_list/misc_info_list_presenter.dart';
 import 'package:ses_novajoj/scene/misc_info_list/misc_info_list_presenter_output.dart';
 import 'package:ses_novajoj/scene/misc_info_list/weather_info_overlay.dart';
 import 'package:ses_novajoj/scene/widgets/info_service_cell.dart';
+import 'package:ses_novajoj/scene/widgets/historio_cell.dart';
 
 class MiscInfoListPage extends StatefulWidget {
   final MiscInfoListPresenter presenter;
@@ -197,7 +198,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
             input: MiscInfoListPresenterInput(
                 appBarTitle: UseL10n.of(context)?.infoServiceFavorites ?? '',
                 viewModelList: viewModelList,
-                serviceType: ServiceType.favorite,
+                serviceType: ServiceType.none,
                 itemIndex: index,
                 completeHandler: () {}));
       },
@@ -209,18 +210,29 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
       {List<MiscInfoListViewModel>? viewModelList}) {
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
-      rowTitles: const <Widget>[],
-      otherTitle: _buildTextWidget(UseL10n.of(context)?.infoServiceItemOther),
+      rowTitles: _buildRowHistorioWidgets(viewModelList!.take(5).toList()),
+      otherTitle: viewModelList.length > 5
+          ? _buildTextWidget(UseL10n.of(context)?.infoServiceItemMore)
+          : null,
+      rowHeight: 80,
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(
                 appBarTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
                 viewModelList: viewModelList,
-                serviceType: ServiceType.history,
+                serviceType: ServiceType.none,
                 itemIndex: index,
                 completeHandler: () {}));
       },
-      onOtherRowSelecting: (index) {},
+      onOtherRowSelecting: (index) {
+        widget.presenter.eventViewHistorioPage(context,
+            input: MiscInfoListPresenterInput(
+                appBarTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
+                viewModelList: viewModelList,
+                serviceType: ServiceType.none,
+                itemIndex: -1,
+                completeHandler: () {}));
+      },
     );
   }
 
@@ -257,6 +269,18 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
                 ))
             .toList() ??
         [];
+  }
+
+  List<Widget> _buildRowHistorioWidgets(List<MiscInfoListViewModel>? infos) {
+    List<Widget> widgets = [];
+    infos?.asMap().forEach((idx, value) {
+      widgets.add(Expanded(
+          child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [HistorioCell(viewModel: value, index: idx)],
+      )));
+    });
+    return widgets;
   }
 
   ///

--- a/lib/scene/misc_info_list/misc_info_list_presenter.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter.dart
@@ -24,9 +24,11 @@ class MiscInfoListPresenterInput {
 abstract class MiscInfoListPresenter
     with SimpleBloc<MiscInfoListPresenterOutput> {
   void eventViewReady({required MiscInfoListPresenterInput input});
-  void eventViewWebPage(Object context,
-      {required MiscInfoListPresenterInput input});
   void eventViewReportPage(Object context,
+      {required MiscInfoListPresenterInput input});
+  void eventViewHistorioPage(Object context,
+      {required MiscInfoListPresenterInput input});
+  void eventViewWebPage(Object context,
       {required MiscInfoListPresenterInput input});
 }
 
@@ -63,6 +65,12 @@ class MiscInfoListPresenterImpl extends MiscInfoListPresenter {
 
   @override
   void eventViewWebPage(Object context,
+      {required MiscInfoListPresenterInput input}) {
+    _viewSelectPage(context, input: input);
+  }
+
+  @override
+  void eventViewHistorioPage(Object context,
       {required MiscInfoListPresenterInput input}) {
     _viewSelectPage(context, input: input);
   }
@@ -115,15 +123,15 @@ class MiscInfoListPresenterImpl extends MiscInfoListPresenter {
       router.gotoReportPage(context,
           appBarTitle: input.appBarTitle,
           itemInfo: itemInfo,
-          removeAction:
-              input.serviceType == ServiceType.weather ? removeAction : null,
+          removeAction: removeAction,
           completeHandler: input.completeHandler);
     } else {
       router.gotoWebPage(context,
           appBarTitle: input.appBarTitle,
           itemInfo: itemInfo,
-          removeAction:
-              input.serviceType == ServiceType.audio ? removeAction : null,
+          removeAction: [ServiceType.audio].contains(input.serviceType)
+              ? null
+              : removeAction,
           completeHandler: input.completeHandler);
     }
   }

--- a/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
@@ -1,4 +1,5 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/foundation/data/user_types_descript.dart';
 import 'package:ses_novajoj/domain/usecases/misc_info_list_usecase_output.dart';
 
 abstract class MiscInfoListPresenterOutput {}
@@ -10,8 +11,22 @@ class ShowMiscInfoListPageModel extends MiscInfoListPresenterOutput {
 }
 
 class MiscInfoListViewModel {
-  NovaItemInfo itemInfo;
+  late NovaItemInfo itemInfo;
+  HistorioInfo? hisInfo;
+  late String createdAtText;
 
   MiscInfoListViewModel(MiscInfoListUseCaseRowModel model)
-      : itemInfo = model.itemInfo;
+      : itemInfo = model.itemInfo,
+        createdAtText = "2022/10/1";
+
+  // FIXME:
+  MiscInfoListViewModel.dummyData({HistorioInfo? hisInfo}) {
+    itemInfo = NovaItemInfo(
+        id: 0,
+        title: "title",
+        urlString: "urlString",
+        createAt: DateTime.now());
+    hisInfo = hisInfo;
+    createdAtText = "";
+  }
 }

--- a/lib/scene/misc_info_list/misc_info_list_router.dart
+++ b/lib/scene/misc_info_list/misc_info_list_router.dart
@@ -17,6 +17,8 @@ abstract class MiscInfoListRouter {
       Object? itemInfo,
       Object? removeAction,
       Object? completeHandler});
+  void gotoHistorioPage(Object context,
+      {required String appBarTitle, Object? itemInfo, Object? completeHandler});
 }
 
 class MiscInfoListRouterImpl extends MiscInfoListRouter {
@@ -161,6 +163,22 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
           WeeklyReportParamKeys.menuActions: menuActions
         }).then((value) {
       if (completeHandler is Function) {
+        completeHandler.call();
+      }
+    });
+  }
+
+  @override
+  void gotoHistorioPage(Object context,
+      {required String appBarTitle,
+      Object? itemInfo,
+      Object? completeHandler}) {
+    Navigator.pushNamed(context as BuildContext, ScreenRouteName.historio.name,
+        arguments: {
+          HistorioParamKeys.appBarTitle: appBarTitle,
+          HistorioParamKeys.itemInfo: itemInfo
+        }).then((value) {
+      if (completeHandler != null && completeHandler is Function) {
         completeHandler.call();
       }
     });

--- a/lib/scene/widgets/historio_cell.dart
+++ b/lib/scene/widgets/historio_cell.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+//import 'package:ses_novajoj/scene/misc_info_list/misc_info_list_presenter_output.dart';
+
+typedef CellSelectingDelegate = void Function(int);
+typedef ThumbnameShowingDelegate = Future<String> Function(int);
+
+class HistorioCell extends StatelessWidget {
+  final dynamic viewModel;
+  final int index;
+  final CellSelectingDelegate? onCellSelecting;
+  final ThumbnameShowingDelegate? onThumbnailShowing;
+  double _screenWidth = 0;
+
+  HistorioCell(
+      {Key? key,
+      required this.viewModel,
+      required this.index,
+      this.onCellSelecting,
+      this.onThumbnailShowing})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    _screenWidth = MediaQuery.of(context).size.width;
+    print('_screenWidth = $_screenWidth');
+    return InkWell(
+        onTap: () {
+          onCellSelecting?.call(index);
+        },
+        splashColor: Colors.black12,
+        splashFactory: InkRipple.splashFactory,
+        child: Container(
+            padding: const EdgeInsets.only(left: 2.0, right: 2.0),
+            child: Column(children: [
+              /*viewModel.createdAtText.isNotEmpty
+                  ?*/
+              Container(
+                alignment: Alignment.topLeft,
+                height: 18,
+                width: MediaQuery.of(context).size.width - 100,
+                child: Text("viewModel.createdAtText"),
+              ),
+              // : const SizedBox(height: 0, width: 0),
+              Row(mainAxisSize: MainAxisSize.min, children: [
+                SizedBox(
+                    width: 26,
+                    child: Text('东西南北',
+                        style: TextStyle(
+                            fontSize:
+                                13)) /*Text(viewModel.hisInfo?.category ?? ''*/),
+                const SizedBox(width: 5),
+                Container(
+                  alignment: Alignment.topCenter,
+                  child: SizedBox(
+                      width: 37.5,
+                      height: 30,
+                      child: FutureBuilder(
+                        future: (String url) async {
+                          String thumbUrl =
+                              await onThumbnailShowing?.call(index) ?? '';
+                          return thumbUrl;
+                        }(viewModel.hisInfo?.itemInfo.urlString ?? ''),
+                        builder: (context, snapshot) {
+                          String blankUrl =
+                              "assets/images/icon_top_cell_blank.png";
+                          if (!snapshot.hasData) {
+                            return Image.asset(blankUrl);
+                          }
+                          String thumbUrl = blankUrl;
+                          if (snapshot.data is String) {
+                            thumbUrl = snapshot.data as String? ?? "";
+                          }
+                          if (thumbUrl.isNotEmpty && thumbUrl != blankUrl) {
+                            return Image.network(thumbUrl,
+                                errorBuilder: (context, object, stackTrace) =>
+                                    Image.asset(blankUrl));
+                          }
+                          return Image.asset(blankUrl);
+                        },
+                      )),
+                ),
+                const SizedBox(width: 5),
+                SizedBox(
+                    width: _screenWidth <= 320 ? 100 : _screenWidth - 165,
+                    child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                              "viewModel.hisInfo?.itemInfo.title ?? '', 1111111",
+                              softWrap: true,
+                              style: const TextStyle(
+                                  fontSize: 14.0,
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xff333333))),
+                          const SizedBox(height: 3),
+                          Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                const SizedBox(width: 1, height: 20),
+                                Container(
+                                    width: 120,
+                                    height: 16,
+                                    alignment: Alignment.bottomLeft,
+                                    child: Text(
+                                        "viewModel.hisInfo?.itemInfo.source ?? ''",
+                                        overflow: TextOverflow.ellipsis,
+                                        style: const TextStyle(
+                                            fontSize: 11.0,
+                                            color: Colors.black54))),
+                                const SizedBox(width: 2),
+                                Container(
+                                    width: 100,
+                                    height: 16,
+                                    alignment: Alignment.bottomRight,
+                                    child: Text(
+                                        "10/19/1" /*viewModel.hisInfo?.createdAt.toString() ?? ''*/,
+                                        style: const TextStyle(
+                                            fontSize: 11.0,
+                                            color: Colors.grey,
+                                            textBaseline:
+                                                TextBaseline.ideographic))),
+                              ])
+                        ]))
+              ]),
+            ])));
+  }
+
+  double _calculateAutoscaleWidth(BuildContext context, String text,
+      {required double fontSize, double deltaWith = 200}) {
+    final textPainter = TextPainter(textDirection: TextDirection.ltr);
+    final style = TextStyle(fontSize: fontSize);
+    textPainter.text = TextSpan(text: text, style: style);
+    textPainter.layout();
+    double maxWidth = (double screenWidth) {
+      double deltaWidth_ = screenWidth <= 320 ? 15 : 0;
+      return screenWidth - deltaWith - deltaWidth_;
+    }(_screenWidth);
+    return textPainter.width >= maxWidth ? maxWidth : textPainter.width;
+  }
+}

--- a/lib/scene/widgets/info_service_cell.dart
+++ b/lib/scene/widgets/info_service_cell.dart
@@ -9,6 +9,7 @@ class InfoServiceCell extends StatelessWidget {
   final String sectionTitle;
   final List<Widget> rowTitles;
   final Widget? otherTitle;
+  final double rowHeight;
   final _RowSelectingDelegate? onRowSelecting;
   final _RowStartSelectingDelegate? onRowStartSelecting;
   final _OtherRowLongPressDelegate? onRowLongPress;
@@ -19,6 +20,7 @@ class InfoServiceCell extends StatelessWidget {
       required this.sectionTitle,
       required this.rowTitles,
       this.otherTitle,
+      this.rowHeight = 40,
       this.onRowSelecting,
       this.onRowStartSelecting,
       this.onRowLongPress,
@@ -78,7 +80,7 @@ class InfoServiceCell extends StatelessWidget {
                       onLongPress: () => onRowLongPress?.call(idx),
                       child: Container(
                           width: screenWidth - 80,
-                          height: 40,
+                          height: rowHeight,
                           alignment: Alignment.center,
                           child: element),
                     ),


### PR DESCRIPTION
History page (phase-9)

General:

- generates `hsitory` page layout (Viper files)

Misc info list page:

- provides `history` page transforming route.
- display  5 items of `history`.

Other:

Widgets:

- create the `history cell` for displaying history infos