### PR TITLE
Feature/sn 042 add historio page logic

### DIFF
--- a/lib/data/repositories/bbs_nova_detail_repository.dart
+++ b/lib/data/repositories/bbs_nova_detail_repository.dart
@@ -1,9 +1,14 @@
+import 'dart:convert';
+
 import 'package:ses_novajoj/foundation/data/result.dart';
+import 'package:ses_novajoj/foundation/data/user_data.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/networking/api/bbs_nova_web_api.dart';
 import 'package:ses_novajoj/networking/response/bbs_detalo_item_response.dart';
 import 'package:ses_novajoj/networking/request/nova_detalo_parameter.dart';
 import 'package:ses_novajoj/domain/entities/bbs_nova_detail_item.dart';
 import 'package:ses_novajoj/domain/repositories/bbs_nova_detail_repository.dart';
+import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 
 class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
   final BbsNovaWebApi _api;
@@ -28,6 +33,8 @@ class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
       if (response != null) {
         retVal = BbsNovaDetailItem(
             itemInfo: response.itemInfo, bodyString: response.bodyString);
+        // save historio
+        _saveHistory(detailItem: retVal);
       } else {
         assert(false, "Unresolved error: response is null");
       }
@@ -36,5 +43,22 @@ class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
       ret = Result.failure(error: error);
     });
     return ret;
+  }
+
+  void _saveHistory({BbsNovaDetailItem? detailItem}) {
+    if (detailItem != null) {
+      HistorioInfo historioInfo = () {
+        HistorioInfo info = HistorioInfo();
+        info.category = 'bbs';
+        info.id = info.hashCode;
+        info.createdAt = DateTime.now();
+        info.itemInfo = detailItem.itemInfo;
+        return info;
+      }();
+      HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
+      final json = historioItemRes.toJson();
+      final encoded = jsonEncode(json);
+      UserData().insertHistorio(historio: encoded);
+    }
   }
 }

--- a/lib/data/repositories/bbs_nova_detail_repository.dart
+++ b/lib/data/repositories/bbs_nova_detail_repository.dart
@@ -34,7 +34,9 @@ class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
         retVal = BbsNovaDetailItem(
             itemInfo: response.itemInfo, bodyString: response.bodyString);
         // save historio
-        _saveHistory(detailItem: retVal);
+        Future.delayed(const Duration(seconds: 1), () {
+          _saveHistory(detailItem: retVal);
+        });
       } else {
         assert(false, "Unresolved error: response is null");
       }
@@ -52,13 +54,15 @@ class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
         info.category = 'bbs';
         info.id = info.hashCode;
         info.createdAt = DateTime.now();
+        info.htmlText = detailItem.toHtmlString();
         info.itemInfo = detailItem.itemInfo;
         return info;
       }();
       HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
       final json = historioItemRes.toJson();
       final encoded = jsonEncode(json);
-      UserData().insertHistorio(historio: encoded);
+      UserData().insertHistorio(
+          historio: encoded, url: historioInfo.itemInfo.urlString);
     }
   }
 }

--- a/lib/data/repositories/historio_repository.dart
+++ b/lib/data/repositories/historio_repository.dart
@@ -1,31 +1,27 @@
+import 'dart:convert';
 import 'package:ses_novajoj/foundation/data/result.dart';
-//import 'package:ses_novajoj/networking/api/my_web_api.dart';
-// import 'package:ses_novajoj/networking/response/historio_item_response.dart';
-// import 'package:ses_novajoj/networking/request/historio_item_parameter.dart';
 import 'package:ses_novajoj/domain/entities/historio_item.dart';
 import 'package:ses_novajoj/domain/repositories/historio_repository.dart';
-
-/// TODO: This is dummy Web API class.
-/// You should  web api class is defined in its dart file, like `my_web_api.dart`
-class MyWebApi {}
+import 'package:ses_novajoj/foundation/data/user_data.dart';
+import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 
 class HistorioRepositoryImpl extends HistorioRepository {
-  final MyWebApi _api;
-
   // sigleton
   static final HistorioRepositoryImpl _instance =
       HistorioRepositoryImpl._internal();
-  HistorioRepositoryImpl._internal() : _api = MyWebApi();
+  HistorioRepositoryImpl._internal();
   factory HistorioRepositoryImpl() => _instance;
 
   @override
-  Future<Result<HistorioItem>> fetchHistorio(
-
+  Future<Result<List<HistorioItem>>> fetchHistorio(
       {required FetchHistorioRepoInput input}) async {
-    Result<HistorioItem> result =
-        Result.success(data: HistorioItem(id: 9999, string: "9999"));    // TODO: call api
-
-    // TODO: change api result for `Historio' repository
+    final historioStrings = UserData().miscHistorioList;
+    final list = historioStrings.map((elem) {
+      final jsonData = json.decode(elem);
+      HistorioItemRes itemRes = HistorioItemRes.fromJson(jsonData);
+      return HistorioItem.copy(from: itemRes);
+    }).toList();
+    Result<List<HistorioItem>> result = Result.success(data: list);
     return result;
   }
 }

--- a/lib/data/repositories/misc_info_list_repository.dart
+++ b/lib/data/repositories/misc_info_list_repository.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:ses_novajoj/foundation/data/result.dart';
 import 'package:ses_novajoj/networking/api/weather_web_api.dart';
+import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 import 'package:ses_novajoj/networking/response/weather_item_response.dart';
 import 'package:ses_novajoj/networking/request/weather_item_parameter.dart';
 import 'package:ses_novajoj/domain/entities/misc_info_list_item.dart';
@@ -23,8 +26,8 @@ class MiscInfoListRepositoryImpl extends MiscInfoListRepository {
   Future<Result<List<MiscInfoListItem>>> fetchMiscInfoList(
       {required FetchMiscInfoListRepoInput input}) async {
     // prepare to get pref data
-    final miscMyTimes = UserData().miscMyTimes;
-    final miscMyOnlineSites = UserData().miscOnlineSites;
+    List<SimpleUrlInfo> miscMyTimes = UserData().miscMyTimes;
+    List<SimpleUrlInfo> miscMyOnlineSites = UserData().miscOnlineSites;
     List<CityInfo> miscWeatherCities = () {
       final ret = UserData().miscWeatherCities;
       if (ret.isEmpty) {
@@ -32,6 +35,7 @@ class MiscInfoListRepositoryImpl extends MiscInfoListRepository {
       }
       return ret;
     }();
+    List<HistorioInfo> miscHistorioList = _getHistorioList();
 
     // make return value
     List<MiscInfoListItem> data = await () async {
@@ -91,8 +95,25 @@ class MiscInfoListRepositoryImpl extends MiscInfoListRepository {
           )),
         );
       }
+      // history
+      id = 0;
+      orderIndex = 0;
+      for (int idx = 0; idx < miscHistorioList.length; idx++) {
+        ret.add(MiscInfoListItem(
+            itemInfo: NovaItemInfo(
+              id: id,
+              urlString: 'http://',
+              title: 'Weather',
+              createAt: DateTime.now(),
+              serviceType: ServiceType.none,
+              orderIndex: orderIndex++,
+            ),
+            hisInfo: miscHistorioList[idx]));
+      }
+
       return ret;
     }();
+
     Result<List<MiscInfoListItem>> result = Result.success(data: data);
     return result;
   }
@@ -160,5 +181,15 @@ class MiscInfoListRepositoryImpl extends MiscInfoListRepository {
           return CityInfoDescript.fromCurrentLocale(name: 'New York');
       }
     }();
+  }
+
+  List<HistorioInfo> _getHistorioList() {
+    final historioStrings = UserData().miscHistorioList;
+    List<HistorioInfo> list = historioStrings.map((elem) {
+      final jsonData = json.decode(elem);
+      HistorioItemRes itemRes = HistorioItemRes.fromJson(jsonData);
+      return itemRes;
+    }).toList();
+    return list;
   }
 }

--- a/lib/data/repositories/misc_info_list_repository.dart
+++ b/lib/data/repositories/misc_info_list_repository.dart
@@ -100,14 +100,13 @@ class MiscInfoListRepositoryImpl extends MiscInfoListRepository {
       orderIndex = 0;
       for (int idx = 0; idx < miscHistorioList.length; idx++) {
         ret.add(MiscInfoListItem(
-            itemInfo: NovaItemInfo(
-              id: id,
-              urlString: 'http://',
-              title: 'Weather',
-              createAt: DateTime.now(),
-              serviceType: ServiceType.none,
-              orderIndex: orderIndex++,
-            ),
+            itemInfo: (NovaItemInfo info) {
+              final NovaItemInfo itemInfo = info;
+              itemInfo.orderIndex = orderIndex++;
+              itemInfo.id = idx;
+              itemInfo.serviceType = ServiceType.none;
+              return itemInfo;
+            }(miscHistorioList[idx].itemInfo),
             hisInfo: miscHistorioList[idx]));
       }
 

--- a/lib/data/repositories/nova_detail_repository.dart
+++ b/lib/data/repositories/nova_detail_repository.dart
@@ -1,5 +1,10 @@
+import 'dart:convert';
+
 import 'package:ses_novajoj/foundation/data/result.dart';
+import 'package:ses_novajoj/foundation/data/user_data.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/networking/api/nova_web_api.dart';
+import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 import 'package:ses_novajoj/networking/response/nova_detalo_item_response.dart';
 import 'package:ses_novajoj/networking/request/nova_detalo_parameter.dart';
 import 'package:ses_novajoj/domain/entities/nova_detail_item.dart';
@@ -28,6 +33,10 @@ class NovaDetailRepositoryImpl extends NovaDetailRepository {
       if (response != null) {
         retVal = NovaDetailItem(
             itemInfo: response.itemInfo, bodyString: response.bodyString);
+        // save historio
+        Future.delayed(const Duration(seconds: 1), () {
+          _saveHistory(detailItem: retVal);
+        });
       } else {
         assert(false, "Unresolved error: response is null");
       }
@@ -36,5 +45,24 @@ class NovaDetailRepositoryImpl extends NovaDetailRepository {
       ret = Result.failure(error: error);
     });
     return ret;
+  }
+
+  void _saveHistory({NovaDetailItem? detailItem}) {
+    if (detailItem != null) {
+      HistorioInfo historioInfo = () {
+        HistorioInfo info = HistorioInfo();
+        info.category = 'news';
+        info.id = info.hashCode;
+        info.createdAt = DateTime.now();
+        info.htmlText = detailItem.toHtmlString();
+        info.itemInfo = detailItem.itemInfo;
+        return info;
+      }();
+      HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
+      final json = historioItemRes.toJson();
+      final encoded = jsonEncode(json);
+      UserData().insertHistorio(
+          historio: encoded, url: historioInfo.itemInfo.urlString);
+    }
   }
 }

--- a/lib/domain/entities/historio_item.dart
+++ b/lib/domain/entities/historio_item.dart
@@ -1,12 +1,11 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/date_util.dart';
 
-class HistorioItem {
-  int id;
-  String string;
-
-  HistorioItem({
-    required this.id,
-    required this.string,
-  });
+class HistorioItem extends HistorioInfo {
+  HistorioItem.copy({required HistorioInfo from}) {
+    id = from.id;
+    createdAt = from.createdAt;
+    category = from.category;
+    itemInfo = from.itemInfo;
+  }
 }

--- a/lib/domain/entities/historio_item.dart
+++ b/lib/domain/entities/historio_item.dart
@@ -1,5 +1,4 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
-import 'package:ses_novajoj/foundation/data/date_util.dart';
 
 class HistorioItem extends HistorioInfo {
   HistorioItem.copy({required HistorioInfo from}) {
@@ -7,5 +6,6 @@ class HistorioItem extends HistorioInfo {
     createdAt = from.createdAt;
     category = from.category;
     itemInfo = from.itemInfo;
+    htmlText = from.htmlText;
   }
 }

--- a/lib/domain/entities/misc_info_list_item.dart
+++ b/lib/domain/entities/misc_info_list_item.dart
@@ -2,8 +2,7 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 
 class MiscInfoListItem {
   NovaItemInfo itemInfo;
+  HistorioInfo? hisInfo;
 
-  MiscInfoListItem({
-    required this.itemInfo,
-  });
+  MiscInfoListItem({required this.itemInfo, this.hisInfo});
 }

--- a/lib/domain/repositories/historio_repository.dart
+++ b/lib/domain/repositories/historio_repository.dart
@@ -2,14 +2,9 @@ import 'package:ses_novajoj/domain/entities/historio_item.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/result.dart';
 
-class FetchHistorioRepoInput {
-  Object id;
-  String string;
-
-  FetchHistorioRepoInput({required this.id, required this.string});
-}
+class FetchHistorioRepoInput {}
 
 abstract class HistorioRepository {
-  Future<Result<HistorioItem>> fetchHistorio(
+  Future<Result<List<HistorioItem>>> fetchHistorio(
       {required FetchHistorioRepoInput input});
 }

--- a/lib/domain/repositories/historio_repository.dart
+++ b/lib/domain/repositories/historio_repository.dart
@@ -1,5 +1,4 @@
 import 'package:ses_novajoj/domain/entities/historio_item.dart';
-import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/result.dart';
 
 class FetchHistorioRepoInput {}

--- a/lib/domain/usecases/historio_usecase.dart
+++ b/lib/domain/usecases/historio_usecase.dart
@@ -1,7 +1,6 @@
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/repositories/historio_repository.dart';
 import 'package:ses_novajoj/data/repositories/historio_repository.dart';
-import 'package:ses_novajoj/foundation/data/user_types.dart';
 
 import 'historio_usecase_output.dart';
 

--- a/lib/domain/usecases/historio_usecase.dart
+++ b/lib/domain/usecases/historio_usecase.dart
@@ -5,12 +5,11 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 
 import 'historio_usecase_output.dart';
 
-class HistorioUseCaseInput {
-
-}
+class HistorioUseCaseInput {}
 
 abstract class HistorioUseCase with SimpleBloc<HistorioUseCaseOutput> {
-  void fetchHistorio({required HistorioUseCaseInput input});
+  Future<HistorioUseCaseOutput> fetchHistorio(
+      {required HistorioUseCaseInput input});
 }
 
 class HistorioUseCaseImpl extends HistorioUseCase {
@@ -18,16 +17,17 @@ class HistorioUseCaseImpl extends HistorioUseCase {
   HistorioUseCaseImpl() : repository = HistorioRepositoryImpl();
 
   @override
-  void fetchHistorio({required HistorioUseCaseInput input}) async {
-    final result = await repository.fetchHistorio(
-        input: FetchHistorioRepoInput(
-            id: 9999, string: "99999" /* // TODO: dummy code*/));
+  Future<HistorioUseCaseOutput> fetchHistorio(
+      {required HistorioUseCaseInput input}) async {
+    final result =
+        await repository.fetchHistorio(input: FetchHistorioRepoInput());
+    late List<HistorioUseCaseModel> list;
+    result.when(
+        success: (value) {
+          list = value.map((elem) => HistorioUseCaseModel(elem)).toList();
+        },
+        failure: (error) {});
 
-    result.when(success: (value) {
-      streamAdd(
-          PresentModel(model: HistorioUseCaseModel(9999, value.toString() /* // TODO: dummy code*/)));
-    }, failure: (error) {
-      streamAdd(PresentModel(error: error));
-    });
+    return PresentModel(models: list);
   }
 }

--- a/lib/domain/usecases/historio_usecase_output.dart
+++ b/lib/domain/usecases/historio_usecase_output.dart
@@ -1,16 +1,15 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 
-abstract class  HistorioUseCaseOutput {}
+abstract class HistorioUseCaseOutput {}
 
 class PresentModel extends HistorioUseCaseOutput {
-  final HistorioUseCaseModel? model;
+  final List<HistorioUseCaseModel>? models;
   final AppError? error;
-  PresentModel({this.model, this.error});
+  PresentModel({this.models, this.error});
 }
 
 class HistorioUseCaseModel {
-  int id;
-  String string;
+  HistorioInfo hisInfo;
 
-  HistorioUseCaseModel(this.id, this.string);
+  HistorioUseCaseModel(this.hisInfo);
 }

--- a/lib/domain/usecases/misc_info_list_usecase_output.dart
+++ b/lib/domain/usecases/misc_info_list_usecase_output.dart
@@ -11,6 +11,8 @@ class PresentModel extends MiscInfoListUseCaseOutput {
 
 class MiscInfoListUseCaseRowModel {
   NovaItemInfo itemInfo;
+  HistorioInfo? hisInfo;
   MiscInfoListUseCaseRowModel(MiscInfoListItem entity)
-      : itemInfo = entity.itemInfo;
+      : itemInfo = entity.itemInfo,
+        hisInfo = entity.hisInfo;
 }

--- a/lib/foundation/data/user_data.dart
+++ b/lib/foundation/data/user_data.dart
@@ -8,6 +8,7 @@ enum _UserDataKey {
   miscMyTimes,
   miscOnlineSites,
   miscWeatherCities,
+  miscHistory
 }
 
 extension _UserDataKeyInfo on _UserDataKey {
@@ -19,6 +20,8 @@ extension _UserDataKeyInfo on _UserDataKey {
         return 'misc_online_sites';
       case _UserDataKey.miscWeatherCities:
         return 'misc_weather_cities';
+      case _UserDataKey.miscHistory:
+        return 'misc_history';
       default:
         return '';
     }
@@ -36,14 +39,15 @@ class UserData {
   /// variables for properties
   final List<SimpleUrlInfo> _miscMyTimes = [];
   final List<SimpleUrlInfo> _miscOnlineSites = [];
-  //final List<SimpleCityInfo> _miscWeatherCities = [];
   final List<CityInfo> _miscWeatherCities = [];
+  final List<String> _miscHistorioList = [];
 
   final EncryptedSharedPreferences _preferences = EncryptedSharedPreferences();
 
   List<SimpleUrlInfo> get miscMyTimes => _miscMyTimes;
   List<SimpleUrlInfo> get miscOnlineSites => _miscOnlineSites;
   List<CityInfo> get miscWeatherCities => _miscWeatherCities;
+  List<String> get miscHistorioList => _miscHistorioList;
 
   ///
   /// read all keys and their values
@@ -65,6 +69,11 @@ class UserData {
     _miscWeatherCities.clear();
     _getCityInfoList(
         key: _UserDataKey.miscWeatherCities.name, outData: _miscWeatherCities);
+
+    // _miscWeatherCities
+    _miscHistorioList.clear();
+    _getHistorioList(
+        key: _UserDataKey.miscHistory.name, outData: _miscHistorioList);
   }
 
   ///
@@ -95,29 +104,6 @@ class UserData {
   }
 
   ///
-  /// getSimpleCityInfoList
-  ///
-  /// ignore: unused_element
-  void _getSimpleCityInfoList(
-      {required String key, required List<SimpleCityInfo> outData}) async {
-    String savedValue = await _preferences.getString(key);
-    savedValue =
-        savedValue.isEmpty ? '{"$_kDefaultListValueKey":[]}' : savedValue;
-
-    final jsonData = await json.decode(savedValue);
-    final parsed = jsonData[_kDefaultListValueKey] as List?;
-    final list =
-        parsed?.map((elem) => SimpleCityInfoDescript.fromJson(elem)).toList() ??
-            [];
-    list.asMap().forEach((idx, value) {
-      outData.add(SimpleCityInfo(
-          name: value.name,
-          langCode: value.langCode,
-          countryCode: value.countryCode));
-    });
-  }
-
-  ///
   /// getCityInfoList
   ///
   void _getCityInfoList(
@@ -130,6 +116,28 @@ class UserData {
     final parsed = jsonData[_kDefaultListValueKey] as List?;
     final list =
         parsed?.map((elem) => CityInfoDescript.fromJson(elem)).toList() ?? [];
+    list.asMap().forEach((idx, value) {
+      outData.add(value);
+    });
+  }
+
+  ///
+  /// _getHistorioList
+  ///
+  void _getHistorioList(
+      {required String key, required List<String> outData}) async {
+    String savedValue = await _preferences.getString(key);
+    if (savedValue.isEmpty) {
+      return;
+    }
+    savedValue =
+        savedValue.isEmpty ? '{"$_kDefaultListValueKey":[]}' : savedValue;
+
+    Codec<String, String> codec = utf8.fuse(base64);
+    final decoded = codec.decode(savedValue);
+    final jsonData = json.decode(decoded);
+    final parsed = jsonData[_kDefaultListValueKey] as List?;
+    final list = parsed?.map((elem) => elem).toList() ?? [];
     list.asMap().forEach((idx, value) {
       outData.add(value);
     });
@@ -202,6 +210,15 @@ class UserData {
     return retVal;
   }
 
+  void insertHistorio({required String historio}) {
+    if (_miscHistorioList.contains(historio)) {
+      return;
+    }
+    _miscHistorioList.insert(0, historio);
+    _saveHistorioList(
+        newValues: _miscHistorioList, key: _UserDataKey.miscHistory.name);
+  }
+
   ///
   /// saveSimpleUrlInfoList
   ///
@@ -220,17 +237,18 @@ class UserData {
   }
 
   ///
-  /// _saveSimpleCityInfoList
+  /// _saveHistorioList
   ///
-  // ignore: unused_element
-  void _saveSimpleCityInfoList(
-      {required List<SimpleCityInfo> newValues, required String key}) {
-    final jsonList = newValues.map((elem) => elem.toJson()).toList();
+  void _saveHistorioList(
+      {required List<String> newValues, required String key}) {
+    final jsonList = newValues;
     final Map<String, dynamic> jsonData = <String, dynamic>{};
     jsonData[_kDefaultListValueKey] = jsonList;
     final encoded = jsonEncode(jsonData);
+    Codec<String, String> codec = utf8.fuse(base64);
+    final encoded2 = codec.encode(encoded);
 
-    _preferences.setString(key, encoded).then((succeeded) {
+    _preferences.setString(key, encoded2).then((succeeded) {
       if (!succeeded) {
         log.warning('Cannot save $key info SharedPref!');
       }

--- a/lib/foundation/data/user_data.dart
+++ b/lib/foundation/data/user_data.dart
@@ -210,8 +210,13 @@ class UserData {
     return retVal;
   }
 
-  void insertHistorio({required String historio}) {
+  void insertHistorio({required String historio, String? url}) {
     if (_miscHistorioList.contains(historio)) {
+      return;
+    } else if (url != null &&
+        _miscHistorioList
+            .firstWhere((element) => element.contains(url), orElse: () => '')
+            .isNotEmpty) {
       return;
     }
     _miscHistorioList.insert(0, historio);

--- a/lib/foundation/data/user_types.dart
+++ b/lib/foundation/data/user_types.dart
@@ -75,18 +75,11 @@ class NovaItemInfo {
 }
 
 class HistorioInfo {
-  int id;
-  DateTime createdAt;
-  String category;
-  NovaItemInfo itemInfo;
+  late int id;
+  late DateTime createdAt;
+  late String category;
+  late NovaItemInfo itemInfo;
   String? htmlText;
-
-  HistorioInfo(
-      {required this.id,
-      required this.createdAt,
-      this.category = '',
-      required this.itemInfo,
-      this.htmlText});
 }
 
 class SimpleUrlInfo {

--- a/lib/foundation/data/user_types_descript.dart
+++ b/lib/foundation/data/user_types_descript.dart
@@ -133,7 +133,7 @@ extension CityInfoDescript on CityInfo {
 
 extension HistorioInfoDescript on HistorioInfo {
   String get createdAtText {
-    return DateUtil().getDateString(date: createdAt, format: 'M/d (E)');
+    return DateUtil().getDateString(date: createdAt, format: 'yyyy/MM/dd');
   }
 }
 

--- a/lib/foundation/data/user_types_descript.dart
+++ b/lib/foundation/data/user_types_descript.dart
@@ -139,7 +139,8 @@ extension HistorioInfoDescript on HistorioInfo {
 
 extension ServiceTypeDescript on ServiceType {
   static ServiceType fromString(String string) {
-    return ServiceType.values.firstWhere((element) => element.name == string);
+    return ServiceType.values.firstWhere((element) => element.name == string,
+        orElse: () => ServiceType.none);
   }
 
   String get stringClass {

--- a/lib/networking/request/historio_item_parameter.dart
+++ b/lib/networking/request/historio_item_parameter.dart
@@ -1,8 +1,0 @@
-import 'package:ses_novajoj/foundation/data/user_types.dart';
-
-class HistorioItemParameter {
-  Object itemInfo;
-  String string;
-
-  HistorioItemParameter({required this.itemInfo, required this.string});
-}

--- a/lib/networking/response/bbs_detalo_item_response.dart
+++ b/lib/networking/response/bbs_detalo_item_response.dart
@@ -1,11 +1,17 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'nova_detalo_item_response.dart';
 
 class BbsDetaloItemRes {
-  NovaItemInfo itemInfo;
-  String bodyString;
+  late NovaItemInfo itemInfo;
+  late String bodyString;
 
   BbsDetaloItemRes({
     required this.itemInfo,
     required this.bodyString,
   });
+
+  BbsDetaloItemRes.copy({required NovaDetaloItemRes from}) {
+    itemInfo = from.itemInfo;
+    bodyString = from.bodyString;
+  }
 }

--- a/lib/networking/response/historio_item_response.dart
+++ b/lib/networking/response/historio_item_response.dart
@@ -1,11 +1,34 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'nova_detalo_item_response.dart';
 
-class HistorioItemItemRes {
-  Object itemInfo;
-  String string;
+class HistorioItemRes extends HistorioInfo {
+  HistorioItemRes.as({required HistorioInfo info}) {
+    id = info.id;
+    category = info.category;
+    createdAt = info.createdAt;
+    htmlText = info.htmlText;
+    itemInfo = info.itemInfo;
+  }
 
-  HistorioItemItemRes({
-    required this.itemInfo,
-    required this.string,
-  });
+  HistorioItemRes.fromJson(Map<String, dynamic> json) {
+    NovaDetaloItemRes detaloItemRes = NovaDetaloItemRes.fromJson(json);
+    id = json['id'];
+    category = json['category'];
+    createdAt = DateTime.parse(json['created_at']);
+    htmlText = detaloItemRes.bodyString;
+    itemInfo = detaloItemRes.itemInfo;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    NovaDetaloItemRes detaloItemRes =
+        NovaDetaloItemRes(bodyString: htmlText ?? '', itemInfo: itemInfo);
+    Map<String, dynamic> detaloItemResData = detaloItemRes.toJson();
+    data['id'] = id;
+    data['category'] = category;
+    data['created_at'] = createdAt.toString();
+    data['html_text'] = htmlText;
+    data['nova_item_info'] = detaloItemResData['nova_item_info'];
+    return data;
+  }
 }

--- a/lib/networking/response/nova_detalo_item_response.dart
+++ b/lib/networking/response/nova_detalo_item_response.dart
@@ -1,4 +1,5 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'package:ses_novajoj/foundation/data/user_types_descript.dart';
 
 class NovaDetaloItemRes {
   NovaItemInfo itemInfo;
@@ -8,4 +9,65 @@ class NovaDetaloItemRes {
     required this.itemInfo,
     required this.bodyString,
   });
+
+  static NovaDetaloItemRes fromJson(Map<String, dynamic> json) {
+    final itemInfo = NovaItemInfoRes.fromJson(json['nova_item_info']);
+    return NovaDetaloItemRes(
+        itemInfo: itemInfo, bodyString: json['html_text'] ?? '');
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['nova_item_info'] = itemInfo.toJson();
+    data['body_string'] = bodyString;
+    return data;
+  }
+}
+
+extension NovaItemInfoRes on NovaItemInfo {
+  static NovaItemInfo fromJson(Map<String, dynamic>? data) {
+    NovaItemInfo itemInfo =
+        NovaItemInfo(id: 0, title: "", urlString: "", createAt: DateTime.now());
+
+    if (data != null) {
+      itemInfo.id = data['id'];
+      itemInfo.serviceType =
+          ServiceTypeDescript.fromString(data['service_type']);
+      itemInfo.title = data['title'];
+      itemInfo.urlString = data['url_string'];
+      itemInfo.title = data['title'];
+      itemInfo.source = data['source'];
+      itemInfo.author = data['author'];
+      itemInfo.createAt = DateTime.parse(data['create_at']);
+      itemInfo.orderIndex = data['order_index'];
+      itemInfo.loadCommentAt = data['load_comment_at'];
+      itemInfo.commentUrlString = data['comment_url_string'];
+      itemInfo.commentCount = data['comment_count'];
+      itemInfo.reads = data['reads'];
+      itemInfo.isRead = data['is_read'];
+      itemInfo.isNew = data['is_new'];
+    }
+    return itemInfo;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+
+    data['id'] = id;
+    data['service_type'] = serviceType.stringClass;
+    data['thunnail_url_string'] = thunnailUrlString;
+    data['title'] = title;
+    data['url_string'] = urlString;
+    data['source'] = source;
+    data['author'] = author;
+    data['create_at'] = createAt.toString();
+    data['order_index'] = orderIndex;
+    data['load_comment_at'] = loadCommentAt;
+    data['comment_url_string'] = commentUrlString;
+    data['comment_count'] = commentCount;
+    data['reads'] = reads;
+    data['is_read'] = isRead;
+    data['is_new'] = isNew;
+    return data;
+  }
 }

--- a/lib/networking/response/nova_detalo_item_response.dart
+++ b/lib/networking/response/nova_detalo_item_response.dart
@@ -35,6 +35,7 @@ extension NovaItemInfoRes on NovaItemInfo {
           ServiceTypeDescript.fromString(data['service_type']);
       itemInfo.title = data['title'];
       itemInfo.urlString = data['url_string'];
+      itemInfo.thunnailUrlString = data['thunnail_url_string'];
       itemInfo.title = data['title'];
       itemInfo.source = data['source'];
       itemInfo.author = data['author'];
@@ -55,9 +56,9 @@ extension NovaItemInfoRes on NovaItemInfo {
 
     data['id'] = id;
     data['service_type'] = serviceType.stringClass;
-    data['thunnail_url_string'] = thunnailUrlString;
     data['title'] = title;
     data['url_string'] = urlString;
+    data['thunnail_url_string'] = thunnailUrlString;
     data['source'] = source;
     data['author'] = author;
     data['create_at'] = createAt.toString();

--- a/lib/networking/response/thread_detalo_item_response.dart
+++ b/lib/networking/response/thread_detalo_item_response.dart
@@ -1,11 +1,17 @@
 import 'package:ses_novajoj/foundation/data/user_types.dart';
+import 'nova_detalo_item_response.dart';
 
 class ThreadDetaloItemRes {
-  NovaItemInfo itemInfo;
-  String bodyString;
+  late NovaItemInfo itemInfo;
+  late String bodyString;
 
   ThreadDetaloItemRes({
     required this.itemInfo,
     required this.bodyString,
   });
+
+  ThreadDetaloItemRes.copy({required NovaDetaloItemRes from}) {
+    itemInfo = from.itemInfo;
+    bodyString = from.bodyString;
+  }
 }

--- a/lib/scene/foundation/page/page_parameter.dart
+++ b/lib/scene/foundation/page/page_parameter.dart
@@ -10,11 +10,17 @@ enum CitySelectParamKeys { appBarTitle, itemInfo, sourceRoute }
 
 enum MiscInfoSelectParamKeys { appBarTitle, itemInfo }
 
-enum HistorioParamKeys { appBarTitle, itemInfo, sourceRoute }
+enum HistorioParamKeys { appBarTitle, itemInfos, sourceRoute }
 
 enum WeeklyReportParamKeys { appBarTitle, itemInfo, menuItems, menuActions }
 
-enum WebPageParamKeys { appBarTitle, itemInfo, menuItems, menuActions }
+enum WebPageParamKeys {
+  appBarTitle,
+  itemInfo,
+  htmlText,
+  menuItems,
+  menuActions
+}
 
 enum DetailMenuItem {
   openOriginal,

--- a/lib/scene/historio/historio_page.dart
+++ b/lib/scene/historio/historio_page.dart
@@ -1,7 +1,4 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:ses_novajoj/foundation/data/user_types.dart';
-import 'package:ses_novajoj/scene/foundation/use_l10n.dart';
 import 'package:ses_novajoj/scene/foundation/color_def.dart';
 import 'package:ses_novajoj/scene/foundation/page/page_parameter.dart';
 import 'package:ses_novajoj/scene/historio/historio_presenter.dart';
@@ -21,7 +18,7 @@ class _HistorioPageState extends State<HistorioPage> {
 
   late String _appBarTitle;
   Map? _parameters;
-  NovaItemInfo? _itemInfo;
+  //NovaItemInfo? _itemInfo;
 
   @override
   void initState() {
@@ -30,15 +27,17 @@ class _HistorioPageState extends State<HistorioPage> {
 
   @override
   Widget build(BuildContext context) {
+    _parseRouteParameter();
+
     return Scaffold(
       appBar: AppBar(
-        //title: Text(_appBarTitle),
+        title: Text(_appBarTitle),
         backgroundColor: ColorDef.appBarBackColor,
         centerTitle: true,
       ),
       body: FutureBuilder<HistorioPresenterOutput>(
-          future:
-              widget.presenter.eventViewReady(input: HistorioPresenterInput()),
+          future: widget.presenter
+              .eventViewReady(input: HistorioPresenterInput(appBarTitle: '')),
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return Center(
@@ -46,42 +45,35 @@ class _HistorioPageState extends State<HistorioPage> {
                       color: Colors.amber, backgroundColor: Colors.grey[850]));
             }
             final data = snapshot.data;
-            if (data is ShowHistorioPageModel && data.viewModelList != null) {
-              final viewModels = data.viewModelList;
+            if (data is ShowHistorioPageModel &&
+                data.reshapedViewModelList != null) {
+              final viewModels = data.reshapedViewModelList;
               return ListView.builder(
                   itemCount: viewModels?.length,
                   itemBuilder: (context, index) => HistorioCell(
                       viewModel: viewModels![index],
                       onCellSelecting: (selIndex) {
-                        /*widget.presenter.eventSelectDetail(context,
-                            appBarTitle: _selectedAppBarTitle,
-                            itemInfo: data.viewModelList![selIndex].itemInfo,
-                            completeHandler: () {
-                        });*/
+                        widget.presenter.eventViewWebPage(context,
+                            input: HistorioPresenterInput(
+                                appBarTitle: _appBarTitle,
+                                viewModel: viewModels[selIndex],
+                                completeHandler: () {}));
                       },
                       onThumbnailShowing: (thumbIndex) async {
-                        if (viewModels[thumbIndex]
+                        return viewModels[thumbIndex]
                             .hisInfo
                             .itemInfo
-                            .thunnailUrlString
-                            .isNotEmpty) {
-                          return viewModels[thumbIndex]
-                              .hisInfo
-                              .itemInfo
-                              .thunnailUrlString;
-                        }
-                        final retUrl =
-                            'http://www.google.com/'; /*await widget.presenter
-                            .eventFetchThumbnail(
-                                targetUrl: data.viewModelList![thumbIndex]
-                                    .itemInfo.urlString);*/
-                        viewModels[thumbIndex]
-                            .hisInfo
-                            .itemInfo
-                            .thunnailUrlString = retUrl;
-                        return retUrl;
+                            .thunnailUrlString;
                       },
-                      index: index));
+                      index: index,
+                      divider: const Divider(
+                          height: 1,
+                          thickness: 1,
+                          color: Colors.black12,
+                          indent: 2,
+                          endIndent: 2),
+                      indent: 0,
+                      endIndent: 0));
             } else {
               return const Text('No data!');
             }
@@ -98,7 +90,7 @@ class _HistorioPageState extends State<HistorioPage> {
     //
     _parameters = ModalRoute.of(context)?.settings.arguments as Map?;
     _appBarTitle = _parameters?[HistorioParamKeys.appBarTitle] as String? ?? '';
-    _itemInfo = _parameters?[HistorioParamKeys.itemInfo] as NovaItemInfo?;
+    // _itemInfo = _parameters?[HistorioParamKeys.itemInfos] as NovaItemInfo?;
 
     //
     // FA

--- a/lib/scene/historio/historio_page.dart
+++ b/lib/scene/historio/historio_page.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
-import 'package:ses_novajoj/domain/foundation/bloc/bloc_provider.dart';
 import 'package:ses_novajoj/scene/foundation/use_l10n.dart';
 import 'package:ses_novajoj/scene/foundation/color_def.dart';
 import 'package:ses_novajoj/scene/foundation/page/page_parameter.dart';
@@ -37,8 +36,9 @@ class _HistorioPageState extends State<HistorioPage> {
         backgroundColor: ColorDef.appBarBackColor,
         centerTitle: true,
       ),
-      body: FutureBuilder<List<HistorioInfo>>(
-          future: () {}(),
+      body: FutureBuilder<HistorioPresenterOutput>(
+          future:
+              widget.presenter.eventViewReady(input: HistorioPresenterInput()),
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return Center(
@@ -46,11 +46,12 @@ class _HistorioPageState extends State<HistorioPage> {
                       color: Colors.amber, backgroundColor: Colors.grey[850]));
             }
             final data = snapshot.data;
-            if (data != null) {
+            if (data is ShowHistorioPageModel && data.viewModelList != null) {
+              final viewModels = data.viewModelList;
               return ListView.builder(
-                  itemCount: data.length,
+                  itemCount: viewModels?.length,
                   itemBuilder: (context, index) => HistorioCell(
-                      viewModel: data[index],
+                      viewModel: viewModels![index],
                       onCellSelecting: (selIndex) {
                         /*widget.presenter.eventSelectDetail(context,
                             appBarTitle: _selectedAppBarTitle,
@@ -59,18 +60,25 @@ class _HistorioPageState extends State<HistorioPage> {
                         });*/
                       },
                       onThumbnailShowing: (thumbIndex) async {
-                        if (data[thumbIndex]
+                        if (viewModels[thumbIndex]
+                            .hisInfo
                             .itemInfo
                             .thunnailUrlString
                             .isNotEmpty) {
-                          return data[thumbIndex].itemInfo.thunnailUrlString;
+                          return viewModels[thumbIndex]
+                              .hisInfo
+                              .itemInfo
+                              .thunnailUrlString;
                         }
                         final retUrl =
                             'http://www.google.com/'; /*await widget.presenter
                             .eventFetchThumbnail(
                                 targetUrl: data.viewModelList![thumbIndex]
                                     .itemInfo.urlString);*/
-                        data[thumbIndex].itemInfo.thunnailUrlString = retUrl;
+                        viewModels[thumbIndex]
+                            .hisInfo
+                            .itemInfo
+                            .thunnailUrlString = retUrl;
                         return retUrl;
                       },
                       index: index));

--- a/lib/scene/historio/historio_presenter.dart
+++ b/lib/scene/historio/historio_presenter.dart
@@ -1,16 +1,22 @@
-import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/usecases/historio_usecase.dart';
 import 'package:ses_novajoj/domain/usecases/historio_usecase_output.dart';
-import 'package:ses_novajoj/viper_templates/templates/lib/foundation/data/result.dart';
 import 'historio_presenter_output.dart';
 
 import 'historio_router.dart';
 
-class HistorioPresenterInput {}
+class HistorioPresenterInput {
+  String appBarTitle;
+  HistorioViewModel? viewModel;
+  Object? completeHandler;
+  HistorioPresenterInput(
+      {required this.appBarTitle, this.viewModel, this.completeHandler});
+}
 
 abstract class HistorioPresenter with SimpleBloc<HistorioPresenterOutput> {
   Future<HistorioPresenterOutput> eventViewReady(
+      {required HistorioPresenterInput input});
+  void eventViewWebPage(Object context,
       {required HistorioPresenterInput input});
 }
 
@@ -30,5 +36,20 @@ class HistorioPresenterImpl extends HistorioPresenter {
       list = output.models?.map((e) => HistorioViewModel(e)).toList();
     }
     return ShowHistorioPageModel(viewModelList: list, error: null);
+  }
+
+  @override
+  void eventViewWebPage(Object context,
+      {required HistorioPresenterInput input}) {
+    _viewSelectPage(context, input: input);
+  }
+
+  void _viewSelectPage(Object context,
+      {required HistorioPresenterInput input}) {
+    router.gotoWebPage(context,
+        appBarTitle: input.appBarTitle,
+        itemInfo: input.viewModel!.hisInfo.itemInfo,
+        htmlText: input.viewModel!.hisInfo.htmlText,
+        completeHandler: input.completeHandler);
   }
 }

--- a/lib/scene/historio/historio_presenter.dart
+++ b/lib/scene/historio/historio_presenter.dart
@@ -2,16 +2,16 @@ import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/usecases/historio_usecase.dart';
 import 'package:ses_novajoj/domain/usecases/historio_usecase_output.dart';
+import 'package:ses_novajoj/viper_templates/templates/lib/foundation/data/result.dart';
 import 'historio_presenter_output.dart';
 
 import 'historio_router.dart';
 
-class HistorioPresenterInput {
-
-}
+class HistorioPresenterInput {}
 
 abstract class HistorioPresenter with SimpleBloc<HistorioPresenterOutput> {
-  void eventViewReady({required HistorioPresenterInput input});
+  Future<HistorioPresenterOutput> eventViewReady(
+      {required HistorioPresenterInput input});
 }
 
 class HistorioPresenterImpl extends HistorioPresenter {
@@ -19,21 +19,16 @@ class HistorioPresenterImpl extends HistorioPresenter {
   final HistorioRouter router;
 
   HistorioPresenterImpl({required this.router})
-      : useCase = HistorioUseCaseImpl() {
-    useCase.stream.listen((event) {
-      if (event is PresentModel) {
-        if (event.error == null) {
-          streamAdd(ShowHistorioPageModel(
-              viewModel: HistorioViewModel(event.model!)));
-        } else {
-          streamAdd(ShowHistorioPageModel(error: event.error));
-        }
-      }
-    });
-  }
+      : useCase = HistorioUseCaseImpl();
 
   @override
-  void eventViewReady({required HistorioPresenterInput input}) {
-    useCase.fetchHistorio(input: HistorioUseCaseInput());
+  Future<HistorioPresenterOutput> eventViewReady(
+      {required HistorioPresenterInput input}) async {
+    final output = await useCase.fetchHistorio(input: HistorioUseCaseInput());
+    List<HistorioViewModel>? list;
+    if (output is PresentModel) {
+      list = output.models?.map((e) => HistorioViewModel(e)).toList();
+    }
+    return ShowHistorioPageModel(viewModelList: list, error: null);
   }
 }

--- a/lib/scene/historio/historio_presenter_output.dart
+++ b/lib/scene/historio/historio_presenter_output.dart
@@ -1,20 +1,24 @@
+import 'package:ses_novajoj/foundation/data/date_util.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/user_types_descript.dart';
-//import 'package:ses_novajoj/domain/usecases/historio_usecase_output.dart';
+import 'package:ses_novajoj/domain/usecases/historio_usecase_output.dart';
 
 abstract class HistorioPresenterOutput {}
 
 class ShowHistorioPageModel extends HistorioPresenterOutput {
-  final HistorioViewModel? viewModel;
+  final List<HistorioViewModel>? viewModelList;
   final AppError? error;
-  ShowHistorioPageModel({this.viewModel, this.error});
+  ShowHistorioPageModel({this.viewModelList, this.error});
 }
 
 class HistorioViewModel {
   HistorioInfo hisInfo;
   String createdAtText;
+  String itemInfoCreatedAtText;
 
-  HistorioViewModel(dynamic model)
+  HistorioViewModel(HistorioUseCaseModel model)
       : hisInfo = model.hisInfo,
-        createdAtText = (model.hisInfo as HistorioInfo?)?.createdAtText ?? '';
+        createdAtText = model.hisInfo.createdAtText,
+        itemInfoCreatedAtText = DateUtil().getDateString(
+            date: model.hisInfo.itemInfo.createAt, format: 'M/d (E)');
 }

--- a/lib/scene/historio/historio_presenter_output.dart
+++ b/lib/scene/historio/historio_presenter_output.dart
@@ -9,6 +9,26 @@ class ShowHistorioPageModel extends HistorioPresenterOutput {
   final List<HistorioViewModel>? viewModelList;
   final AppError? error;
   ShowHistorioPageModel({this.viewModelList, this.error});
+
+  List<HistorioViewModel>? _viewModelList;
+  List<HistorioViewModel>? get reshapedViewModelList => () {
+        if (viewModelList == null) {
+          return null;
+        }
+        if (_viewModelList != null) {
+          return _viewModelList;
+        }
+        HistorioViewModel? prevModel;
+        _viewModelList = [...viewModelList!];
+        for (final HistorioViewModel model in _viewModelList!) {
+          if (prevModel?.createdAtText == model.createdAtText) {
+            model.createdAtText = '';
+          } else {
+            prevModel = model;
+          }
+        }
+        return _viewModelList;
+      }();
 }
 
 class HistorioViewModel {

--- a/lib/scene/historio/historio_router.dart
+++ b/lib/scene/historio/historio_router.dart
@@ -1,13 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:ses_novajoj/scene/foundation/page/page_parameter.dart';
+import 'package:ses_novajoj/scene/foundation/page/screen_route_enums.dart';
+
 abstract class HistorioRouter {
-  //void gotoTop(Object context);
+  void gotoWebPage(Object context,
+      {required String appBarTitle,
+      Object? itemInfo,
+      Object? htmlText,
+      Object? removeAction,
+      Object? completeHandler});
 }
 
 class HistorioRouterImpl extends HistorioRouter {
   HistorioRouterImpl();
 
-  // @override
-  // void gotoTop(Object context) {
-  //   log.info('gotoTop');
-  //   Navigator.pushNamed(context as BuildContext, ScreenRouteName.tabs.name);
-  // }
+  @override
+  void gotoWebPage(Object context,
+      {required String appBarTitle,
+      Object? itemInfo,
+      Object? htmlText,
+      Object? removeAction,
+      Object? completeHandler}) {
+    // customize menu itemsz of detail page
+    BuildContext context_ = context as BuildContext;
+
+    // Transfer to web page / detail page.
+    Navigator.pushNamed(context_, ScreenRouteName.webPage.name, arguments: {
+      WebPageParamKeys.appBarTitle: appBarTitle,
+      WebPageParamKeys.itemInfo: itemInfo,
+      WebPageParamKeys.htmlText: htmlText,
+      WebPageParamKeys.menuItems: null,
+      WebPageParamKeys.menuActions: null
+    }).then((value) {
+      if (completeHandler is Function) {
+        completeHandler.call();
+      }
+    });
+  }
 }

--- a/lib/scene/misc_info_list/misc_info_list_page.dart
+++ b/lib/scene/misc_info_list/misc_info_list_page.dart
@@ -208,6 +208,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
 
   Widget _buildHistoryArea(BuildContext context,
       {List<MiscInfoListViewModel>? viewModelList}) {
+    double screenWidth = MediaQuery.of(context).size.width;
     final hisInfos = viewModelList
         ?.where((element) =>
             element.itemInfo.serviceType == ServiceType.none &&
@@ -220,7 +221,15 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
           ? _buildTextWidget(UseL10n.of(context)?.infoServiceItemMore)
           : null,
       calcRowHeight: (index) {
-        return hisInfos![index].createdAtText.isNotEmpty ? 85 : 65;
+        double itemTitleHeight = _calculateItemTitleHeight(
+            context, hisInfos?[index].itemInfo.title ?? '',
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+            textWidth: (screenWidth <= 320 ? 100 : screenWidth - 165));
+        double retHeight =
+            (hisInfos![index].createdAtText.isNotEmpty ? 45 : 25) +
+                itemTitleHeight;
+        return retHeight;
       },
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
@@ -284,10 +293,33 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
       widgets.add(Expanded(
           child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
-        children: [HistorioCell(viewModel: value, index: idx)],
+        children: [
+          HistorioCell(
+              viewModel: value,
+              index: idx,
+              onThumbnailShowing: (thumbIndex) async {
+                return infos[idx].itemInfo.thunnailUrlString;
+              })
+        ],
       )));
     });
     return widgets;
+  }
+
+  double _calculateItemTitleHeight(BuildContext context, String text,
+      {required double fontSize,
+      required FontWeight fontWeight,
+      required double textWidth,
+      double minTextHeight = 21.0}) {
+    final textPainter = TextPainter(textDirection: TextDirection.ltr);
+    final style = TextStyle(fontSize: fontSize, fontWeight: fontWeight);
+    textPainter.text = TextSpan(text: text, style: style);
+    textPainter.layout();
+    final lines = (textPainter.size.width / textWidth).ceil();
+    final height = lines * textPainter.size.height;
+    return height <= minTextHeight
+        ? minTextHeight
+        : textPainter.height + minTextHeight;
   }
 
   ///

--- a/lib/scene/misc_info_list/misc_info_list_page.dart
+++ b/lib/scene/misc_info_list/misc_info_list_page.dart
@@ -231,15 +231,6 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
                 itemTitleHeight;
         return retHeight;
       },
-      onRowSelecting: (index) {
-        widget.presenter.eventViewWebPage(context,
-            input: MiscInfoListPresenterInput(
-                appBarTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
-                viewModelList: hisInfos,
-                serviceType: ServiceType.none,
-                itemIndex: index,
-                completeHandler: () {}));
-      },
       onOtherRowSelecting: (index) {
         widget.presenter.eventViewHistorioPage(context,
             input: MiscInfoListPresenterInput(
@@ -247,7 +238,10 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
                 viewModelList: hisInfos,
                 serviceType: ServiceType.none,
                 itemIndex: -1,
-                completeHandler: () {}));
+                completeHandler: () {
+                  widget.presenter
+                      .eventViewReady(input: MiscInfoListPresenterInput());
+                }));
       },
     );
   }
@@ -297,6 +291,16 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
           HistorioCell(
               viewModel: value,
               index: idx,
+              onCellSelecting: (index) {
+                widget.presenter.eventViewHistorioWebPage(context,
+                    input: MiscInfoListPresenterInput(
+                        appBarTitle:
+                            UseL10n.of(context)?.infoServiceHistory ?? '',
+                        viewModelList: infos,
+                        serviceType: ServiceType.none,
+                        itemIndex: index,
+                        completeHandler: () {}));
+              },
               onThumbnailShowing: (thumbIndex) async {
                 return infos[idx].itemInfo.thunnailUrlString;
               })
@@ -317,9 +321,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
     textPainter.layout();
     final lines = (textPainter.size.width / textWidth).ceil();
     final height = lines * textPainter.size.height;
-    return height <= minTextHeight
-        ? minTextHeight
-        : textPainter.height + minTextHeight;
+    return height <= minTextHeight ? minTextHeight : height;
   }
 
   ///

--- a/lib/scene/misc_info_list/misc_info_list_page.dart
+++ b/lib/scene/misc_info_list/misc_info_list_page.dart
@@ -61,7 +61,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
                       _buildFavoriteArea(context,
                           viewModelList: data.viewModelList),
                       _buildHistoryArea(context,
-                          viewModelList: data.viewModelList)
+                          viewModelList: data.reshapedViewModelList)
                     ],
                   ));
                 } else {
@@ -219,7 +219,9 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
       otherTitle: (hisInfos?.length ?? 0) > 5
           ? _buildTextWidget(UseL10n.of(context)?.infoServiceItemMore)
           : null,
-      rowHeight: 85,
+      calcRowHeight: (index) {
+        return hisInfos![index].createdAtText.isNotEmpty ? 85 : 65;
+      },
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(

--- a/lib/scene/misc_info_list/misc_info_list_page.dart
+++ b/lib/scene/misc_info_list/misc_info_list_page.dart
@@ -208,18 +208,23 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
 
   Widget _buildHistoryArea(BuildContext context,
       {List<MiscInfoListViewModel>? viewModelList}) {
+    final hisInfos = viewModelList
+        ?.where((element) =>
+            element.itemInfo.serviceType == ServiceType.none &&
+            element.hisInfo != null)
+        .toList();
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
-      rowTitles: _buildRowHistorioWidgets(viewModelList!.take(5).toList()),
-      otherTitle: viewModelList.length > 5
+      rowTitles: _buildRowHistorioWidgets(hisInfos?.take(5).toList()),
+      otherTitle: (hisInfos?.length ?? 0) > 5
           ? _buildTextWidget(UseL10n.of(context)?.infoServiceItemMore)
           : null,
-      rowHeight: 80,
+      rowHeight: 85,
       onRowSelecting: (index) {
         widget.presenter.eventViewWebPage(context,
             input: MiscInfoListPresenterInput(
                 appBarTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
-                viewModelList: viewModelList,
+                viewModelList: hisInfos,
                 serviceType: ServiceType.none,
                 itemIndex: index,
                 completeHandler: () {}));
@@ -228,7 +233,7 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
         widget.presenter.eventViewHistorioPage(context,
             input: MiscInfoListPresenterInput(
                 appBarTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
-                viewModelList: viewModelList,
+                viewModelList: hisInfos,
                 serviceType: ServiceType.none,
                 itemIndex: -1,
                 completeHandler: () {}));

--- a/lib/scene/misc_info_list/misc_info_list_presenter.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter.dart
@@ -26,9 +26,11 @@ abstract class MiscInfoListPresenter
   void eventViewReady({required MiscInfoListPresenterInput input});
   void eventViewReportPage(Object context,
       {required MiscInfoListPresenterInput input});
+  void eventViewWebPage(Object context,
+      {required MiscInfoListPresenterInput input});
   void eventViewHistorioPage(Object context,
       {required MiscInfoListPresenterInput input});
-  void eventViewWebPage(Object context,
+  void eventViewHistorioWebPage(Object context,
       {required MiscInfoListPresenterInput input});
 }
 
@@ -72,7 +74,20 @@ class MiscInfoListPresenterImpl extends MiscInfoListPresenter {
   @override
   void eventViewHistorioPage(Object context,
       {required MiscInfoListPresenterInput input}) {
-    _viewSelectPage(context, input: input);
+    router.gotoHistorioPage(context,
+        itemInfos: input.viewModelList,
+        appBarTitle: input.appBarTitle,
+        completeHandler: input.completeHandler);
+  }
+
+  @override
+  void eventViewHistorioWebPage(Object context,
+      {required MiscInfoListPresenterInput input}) {
+    router.gotoHistorioWebPage(context,
+        itemInfo: input.viewModelList?[input.itemIndex].itemInfo,
+        htmlText: input.viewModelList?[input.itemIndex].hisInfo?.htmlText,
+        appBarTitle: input.appBarTitle,
+        completeHandler: input.completeHandler);
   }
 
   void _viewSelectPage(Object context,

--- a/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
@@ -27,6 +27,7 @@ class ShowMiscInfoListPageModel extends MiscInfoListPresenterOutput {
             prevModel = model;
           }
         }
+        return _viewModelList;
       }();
 }
 

--- a/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
@@ -9,6 +9,25 @@ class ShowMiscInfoListPageModel extends MiscInfoListPresenterOutput {
   final List<MiscInfoListViewModel>? viewModelList;
   final AppError? error;
   ShowMiscInfoListPageModel({this.viewModelList, this.error});
+
+  List<MiscInfoListViewModel>? _viewModelList;
+  List<MiscInfoListViewModel>? get reshapedViewModelList => () {
+        if (viewModelList == null) {
+          return null;
+        }
+        if (_viewModelList != null) {
+          return _viewModelList;
+        }
+        MiscInfoListViewModel? prevModel;
+        _viewModelList = [...viewModelList!];
+        for (final MiscInfoListViewModel model in _viewModelList!) {
+          if (prevModel?.createdAtText == model.createdAtText) {
+            model.createdAtText = '';
+          } else {
+            prevModel = model;
+          }
+        }
+      }();
 }
 
 class MiscInfoListViewModel {

--- a/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter_output.dart
@@ -1,3 +1,4 @@
+import 'package:ses_novajoj/foundation/data/date_util.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/foundation/data/user_types_descript.dart';
 import 'package:ses_novajoj/domain/usecases/misc_info_list_usecase_output.dart';
@@ -11,22 +12,15 @@ class ShowMiscInfoListPageModel extends MiscInfoListPresenterOutput {
 }
 
 class MiscInfoListViewModel {
-  late NovaItemInfo itemInfo;
+  NovaItemInfo itemInfo;
   HistorioInfo? hisInfo;
-  late String createdAtText;
+  String createdAtText;
+  String itemInfoCreatedAtText;
 
   MiscInfoListViewModel(MiscInfoListUseCaseRowModel model)
       : itemInfo = model.itemInfo,
-        createdAtText = "2022/10/1";
-
-  // FIXME:
-  MiscInfoListViewModel.dummyData({HistorioInfo? hisInfo}) {
-    itemInfo = NovaItemInfo(
-        id: 0,
-        title: "title",
-        urlString: "urlString",
-        createAt: DateTime.now());
-    hisInfo = hisInfo;
-    createdAtText = "";
-  }
+        hisInfo = model.hisInfo,
+        createdAtText = model.hisInfo?.createdAtText ?? '',
+        itemInfoCreatedAtText = DateUtil()
+            .getDateString(date: model.itemInfo.createAt, format: 'M/d (E)');
 }

--- a/lib/scene/misc_info_list/misc_info_list_router.dart
+++ b/lib/scene/misc_info_list/misc_info_list_router.dart
@@ -12,13 +12,21 @@ abstract class MiscInfoListRouter {
       Object? itemInfo,
       Object? removeAction,
       Object? completeHandler});
+  void gotoHistorioWebPage(Object context,
+      {required String appBarTitle,
+      Object? itemInfo,
+      Object? htmlText,
+      Object? removeAction,
+      Object? completeHandler});
   void gotoReportPage(Object context,
       {required String appBarTitle,
       Object? itemInfo,
       Object? removeAction,
       Object? completeHandler});
   void gotoHistorioPage(Object context,
-      {required String appBarTitle, Object? itemInfo, Object? completeHandler});
+      {required String appBarTitle,
+      dynamic itemInfos,
+      Object? completeHandler});
 }
 
 class MiscInfoListRouterImpl extends MiscInfoListRouter {
@@ -111,6 +119,29 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
   }
 
   @override
+  void gotoHistorioWebPage(Object context,
+      {required String appBarTitle,
+      Object? itemInfo,
+      Object? htmlText,
+      Object? removeAction,
+      Object? completeHandler}) {
+    // customize menu itemsz of detail page
+    BuildContext context_ = context as BuildContext;
+    // Transfer to web page / detail page.
+    Navigator.pushNamed(context_, ScreenRouteName.webPage.name, arguments: {
+      WebPageParamKeys.appBarTitle: appBarTitle,
+      WebPageParamKeys.itemInfo: itemInfo,
+      WebPageParamKeys.htmlText: htmlText,
+      WebPageParamKeys.menuItems: null,
+      WebPageParamKeys.menuActions: null
+    }).then((value) {
+      if (completeHandler is Function) {
+        completeHandler.call();
+      }
+    });
+  }
+
+  @override
   void gotoReportPage(Object context,
       {required String appBarTitle,
       Object? itemInfo,
@@ -171,12 +202,12 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
   @override
   void gotoHistorioPage(Object context,
       {required String appBarTitle,
-      Object? itemInfo,
+      dynamic itemInfos,
       Object? completeHandler}) {
     Navigator.pushNamed(context as BuildContext, ScreenRouteName.historio.name,
         arguments: {
           HistorioParamKeys.appBarTitle: appBarTitle,
-          HistorioParamKeys.itemInfo: itemInfo
+          HistorioParamKeys.itemInfos: itemInfos
         }).then((value) {
       if (completeHandler != null && completeHandler is Function) {
         completeHandler.call();

--- a/lib/scene/root/web_page.dart
+++ b/lib/scene/root/web_page.dart
@@ -57,7 +57,9 @@ class _WebPageState extends State<WebPage> {
               menuActions: _detailItem?.menuActions),
         ),
         body: _detailPage.buildContentArea(context,
-            detailItem: _detailItem, imageZommingEnabled: false));
+            detailItem: _detailItem,
+            imageZommingEnabled:
+                (_detailItem?.htmlText.isNotEmpty ?? false) ? true : false));
   }
 
   void _parseRouteParameter() {
@@ -70,14 +72,13 @@ class _WebPageState extends State<WebPage> {
       _appBarTitle =
           _parameters?[WebPageParamKeys.appBarTitle] as String? ?? '';
       _itemInfo = _parameters?[WebPageParamKeys.itemInfo] as NovaItemInfo?;
-
       //
       // WebPageDetailItem
       //
       if (_itemInfo != null) {
         _detailItem = WebPageDetailItem(
             itemInfo: _itemInfo!,
-            htmlText: '',
+            htmlText: _parameters?[WebPageParamKeys.htmlText] ?? '',
             menuItems: _parameters?[WebPageParamKeys.menuItems],
             menuActions: _parameters?[WebPageParamKeys.menuActions]);
       }

--- a/lib/scene/widgets/historio_cell.dart
+++ b/lib/scene/widgets/historio_cell.dart
@@ -9,13 +9,19 @@ class HistorioCell extends StatelessWidget {
   final int index;
   final CellSelectingDelegate? onCellSelecting;
   final ThumbnameShowingDelegate? onThumbnailShowing;
+  final Widget? divider;
+  final double indent;
+  final double endIndent;
 
   const HistorioCell(
       {Key? key,
       required this.viewModel,
       required this.index,
       this.onCellSelecting,
-      this.onThumbnailShowing})
+      this.onThumbnailShowing,
+      this.divider,
+      this.indent = 35,
+      this.endIndent = 35})
       : super(key: key);
 
   @override
@@ -32,17 +38,20 @@ class HistorioCell extends StatelessWidget {
             child: Column(children: [
               viewModel.createdAtText.isNotEmpty
                   ? Container(
+                      padding: EdgeInsets.only(left: indent),
+                      color: Colors.grey[100],
                       alignment: Alignment.topLeft,
                       height: 18,
                       width: MediaQuery.of(context).size.width - 100,
-                      child: Text(viewModel.createdAtText),
+                      child: Text(viewModel.createdAtText,
+                          style: const TextStyle(fontSize: 14)),
                     )
                   : const SizedBox(height: 0, width: 0),
               Row(mainAxisSize: MainAxisSize.min, children: [
                 SizedBox(
-                    width: 26,
+                    width: 32,
                     child: Text(viewModel.hisInfo?.category ?? '',
-                        style: const TextStyle(fontSize: 13))),
+                        style: const TextStyle(fontSize: 10))),
                 const SizedBox(width: 5),
                 Container(
                   alignment: Alignment.topCenter,
@@ -65,7 +74,7 @@ class HistorioCell extends StatelessWidget {
                           if (snapshot.data is String) {
                             thumbUrl = snapshot.data as String? ?? "";
                           }
-                          print('thumburl = $thumbUrl');
+
                           if (thumbUrl.isNotEmpty && thumbUrl != blankUrl) {
                             return Image.network(thumbUrl,
                                 errorBuilder: (context, object, stackTrace) =>
@@ -77,7 +86,9 @@ class HistorioCell extends StatelessWidget {
                 ),
                 const SizedBox(width: 5),
                 SizedBox(
-                    width: screenWidth <= 320 ? 100 : screenWidth - 165,
+                    width: screenWidth <= 320
+                        ? 100
+                        : screenWidth - 95 - indent - endIndent,
                     child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -93,7 +104,6 @@ class HistorioCell extends StatelessWidget {
                               children: [
                                 const SizedBox(width: 1, height: 20),
                                 Container(
-                                    width: 120,
                                     height: 16,
                                     alignment: Alignment.bottomLeft,
                                     child: Text(
@@ -103,7 +113,7 @@ class HistorioCell extends StatelessWidget {
                                         style: const TextStyle(
                                             fontSize: 11.0,
                                             color: Colors.black54))),
-                                const SizedBox(width: 2),
+                                const Spacer(),
                                 Container(
                                     width: 100,
                                     height: 16,
@@ -117,6 +127,7 @@ class HistorioCell extends StatelessWidget {
                               ])
                         ]))
               ]),
+              divider != null ? divider! : const SizedBox(height: 0)
             ])));
   }
 }

--- a/lib/scene/widgets/historio_cell.dart
+++ b/lib/scene/widgets/historio_cell.dart
@@ -65,6 +65,7 @@ class HistorioCell extends StatelessWidget {
                           if (snapshot.data is String) {
                             thumbUrl = snapshot.data as String? ?? "";
                           }
+                          print('thumburl = $thumbUrl');
                           if (thumbUrl.isNotEmpty && thumbUrl != blankUrl) {
                             return Image.network(thumbUrl,
                                 errorBuilder: (context, object, stackTrace) =>
@@ -117,21 +118,5 @@ class HistorioCell extends StatelessWidget {
                         ]))
               ]),
             ])));
-  }
-
-  // ignore: unused_element
-  double _calculateAutoscaleWidth(BuildContext context, String text,
-      {required double fontSize,
-      required double screenWidth,
-      double deltaWith = 200}) {
-    final textPainter = TextPainter(textDirection: TextDirection.ltr);
-    final style = TextStyle(fontSize: fontSize);
-    textPainter.text = TextSpan(text: text, style: style);
-    textPainter.layout();
-    double maxWidth = (double screenWidth) {
-      double deltaWidth_ = screenWidth <= 320 ? 15 : 0;
-      return screenWidth - deltaWith - deltaWidth_;
-    }(screenWidth);
-    return textPainter.width >= maxWidth ? maxWidth : textPainter.width;
   }
 }

--- a/lib/scene/widgets/historio_cell.dart
+++ b/lib/scene/widgets/historio_cell.dart
@@ -9,9 +9,8 @@ class HistorioCell extends StatelessWidget {
   final int index;
   final CellSelectingDelegate? onCellSelecting;
   final ThumbnameShowingDelegate? onThumbnailShowing;
-  double _screenWidth = 0;
 
-  HistorioCell(
+  const HistorioCell(
       {Key? key,
       required this.viewModel,
       required this.index,
@@ -21,8 +20,7 @@ class HistorioCell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    _screenWidth = MediaQuery.of(context).size.width;
-    print('_screenWidth = $_screenWidth');
+    double screenWidth = MediaQuery.of(context).size.width;
     return InkWell(
         onTap: () {
           onCellSelecting?.call(index);
@@ -32,22 +30,19 @@ class HistorioCell extends StatelessWidget {
         child: Container(
             padding: const EdgeInsets.only(left: 2.0, right: 2.0),
             child: Column(children: [
-              /*viewModel.createdAtText.isNotEmpty
-                  ?*/
-              Container(
-                alignment: Alignment.topLeft,
-                height: 18,
-                width: MediaQuery.of(context).size.width - 100,
-                child: Text("viewModel.createdAtText"),
-              ),
-              // : const SizedBox(height: 0, width: 0),
+              viewModel.createdAtText.isNotEmpty
+                  ? Container(
+                      alignment: Alignment.topLeft,
+                      height: 18,
+                      width: MediaQuery.of(context).size.width - 100,
+                      child: Text(viewModel.createdAtText),
+                    )
+                  : const SizedBox(height: 0, width: 0),
               Row(mainAxisSize: MainAxisSize.min, children: [
                 SizedBox(
                     width: 26,
-                    child: Text('东西南北',
-                        style: TextStyle(
-                            fontSize:
-                                13)) /*Text(viewModel.hisInfo?.category ?? ''*/),
+                    child: Text(viewModel.hisInfo?.category ?? '',
+                        style: const TextStyle(fontSize: 13))),
                 const SizedBox(width: 5),
                 Container(
                   alignment: Alignment.topCenter,
@@ -81,12 +76,11 @@ class HistorioCell extends StatelessWidget {
                 ),
                 const SizedBox(width: 5),
                 SizedBox(
-                    width: _screenWidth <= 320 ? 100 : _screenWidth - 165,
+                    width: screenWidth <= 320 ? 100 : screenWidth - 165,
                     child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                              "viewModel.hisInfo?.itemInfo.title ?? '', 1111111",
+                          Text(viewModel.hisInfo?.itemInfo.title ?? '',
                               softWrap: true,
                               style: const TextStyle(
                                   fontSize: 14.0,
@@ -102,7 +96,8 @@ class HistorioCell extends StatelessWidget {
                                     height: 16,
                                     alignment: Alignment.bottomLeft,
                                     child: Text(
-                                        "viewModel.hisInfo?.itemInfo.source ?? ''",
+                                        viewModel.hisInfo?.itemInfo.source ??
+                                            '',
                                         overflow: TextOverflow.ellipsis,
                                         style: const TextStyle(
                                             fontSize: 11.0,
@@ -112,8 +107,7 @@ class HistorioCell extends StatelessWidget {
                                     width: 100,
                                     height: 16,
                                     alignment: Alignment.bottomRight,
-                                    child: Text(
-                                        "10/19/1" /*viewModel.hisInfo?.createdAt.toString() ?? ''*/,
+                                    child: Text(viewModel.itemInfoCreatedAtText,
                                         style: const TextStyle(
                                             fontSize: 11.0,
                                             color: Colors.grey,
@@ -125,8 +119,11 @@ class HistorioCell extends StatelessWidget {
             ])));
   }
 
+  // ignore: unused_element
   double _calculateAutoscaleWidth(BuildContext context, String text,
-      {required double fontSize, double deltaWith = 200}) {
+      {required double fontSize,
+      required double screenWidth,
+      double deltaWith = 200}) {
     final textPainter = TextPainter(textDirection: TextDirection.ltr);
     final style = TextStyle(fontSize: fontSize);
     textPainter.text = TextSpan(text: text, style: style);
@@ -134,7 +131,7 @@ class HistorioCell extends StatelessWidget {
     double maxWidth = (double screenWidth) {
       double deltaWidth_ = screenWidth <= 320 ? 15 : 0;
       return screenWidth - deltaWith - deltaWidth_;
-    }(_screenWidth);
+    }(screenWidth);
     return textPainter.width >= maxWidth ? maxWidth : textPainter.width;
   }
 }

--- a/lib/scene/widgets/info_service_cell.dart
+++ b/lib/scene/widgets/info_service_cell.dart
@@ -9,7 +9,7 @@ class InfoServiceCell extends StatelessWidget {
   final String sectionTitle;
   final List<Widget> rowTitles;
   final Widget? otherTitle;
-  final double rowHeight;
+  final double Function(int index)? calcRowHeight;
   final _RowSelectingDelegate? onRowSelecting;
   final _RowStartSelectingDelegate? onRowStartSelecting;
   final _OtherRowLongPressDelegate? onRowLongPress;
@@ -20,13 +20,14 @@ class InfoServiceCell extends StatelessWidget {
       required this.sectionTitle,
       required this.rowTitles,
       this.otherTitle,
-      this.rowHeight = 40,
+      this.calcRowHeight,
       this.onRowSelecting,
       this.onRowStartSelecting,
       this.onRowLongPress,
       this.onOtherRowSelecting})
       : super(key: key);
 
+  static const double kRowHeight = 40;
   @override
   Widget build(BuildContext context) {
     double screenWidth = MediaQuery.of(context).size.width;
@@ -80,7 +81,9 @@ class InfoServiceCell extends StatelessWidget {
                       onLongPress: () => onRowLongPress?.call(idx),
                       child: Container(
                           width: screenWidth - 80,
-                          height: rowHeight,
+                          height: calcRowHeight == null
+                              ? InfoServiceCell.kRowHeight
+                              : calcRowHeight!(idx),
                           alignment: Alignment.center,
                           child: element),
                     ),

--- a/lib/scene/widgets/nova_list_cell.dart
+++ b/lib/scene/widgets/nova_list_cell.dart
@@ -100,7 +100,7 @@ class NovaListCell extends StatelessWidget {
                                         style: const TextStyle(
                                             fontSize: 12.0,
                                             color: Colors.pinkAccent))),
-                                const SizedBox(width: 10),
+                                const Spacer(),
                                 Text(viewModel.createAtText,
                                     style: const TextStyle(
                                         fontSize: 12.0,

--- a/lib/scene/widgets/simple_item_cell.dart
+++ b/lib/scene/widgets/simple_item_cell.dart
@@ -56,7 +56,7 @@ class SimpleItemCwll extends StatelessWidget {
                                         style: const TextStyle(
                                             fontSize: 12.0,
                                             color: Colors.pinkAccent))),
-                                const SizedBox(width: 10),
+                                const Spacer(),
                                 Text(viewModel.createAtText,
                                     style: const TextStyle(
                                         fontSize: 12.0,


### PR DESCRIPTION
History page (phase-10_1)

General:

- encode historioInfo as json
- decode historioInfo from json
- add: read historioInfo from UserData
- add: save historioInfo in UserData

Bbs Detail:

- add: save historioInfo in the repository

Misc Info list:

- add: read historioInfo in the repository
- show historioInfo on the page

History page (phase-10_2)

Misc Info list:

- fix: after reading historioInfo in the repository, reshapes its itemInfo.
- fix: when showing historioInfo on the page, if  `createAt` is the same,sets empty.
- fix: ajusts infoService row height according to its itemInfo.

History page (phase-10_3)

Misc Info list:

- fix: info cell height overflows if item title shows as more than two lines.
- fix: does not show thumbnail.

History page (phase-10_4)

General:

- add: saves quick news history
- add: saves local news history
- add: saves thread info history
- fulfill: shows select history info page

Misc Info list:

- fix: info cell height overflows if item title shows as more than two lines.

Other:

- fix: adjust news item cell
- clear: removes unnecesary files.