### PR TITLE
Feature/sn 045 add favorites historio page edit logic

### DIFF
--- a/lib/data/repositories/bbs_nova_detail_repository.dart
+++ b/lib/data/repositories/bbs_nova_detail_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:ses_novajoj/foundation/data/result.dart';
 import 'package:ses_novajoj/foundation/data/user_data.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
@@ -8,7 +6,6 @@ import 'package:ses_novajoj/networking/response/bbs_detalo_item_response.dart';
 import 'package:ses_novajoj/networking/request/nova_detalo_parameter.dart';
 import 'package:ses_novajoj/domain/entities/bbs_nova_detail_item.dart';
 import 'package:ses_novajoj/domain/repositories/bbs_nova_detail_repository.dart';
-import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 
 class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
   final BbsNovaWebApi _api;
@@ -41,10 +38,6 @@ class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
               return info;
             }(),
             bodyString: response.bodyString);
-        // save historio
-        Future.delayed(const Duration(seconds: 1), () {
-          _saveHistory(detailItem: retVal);
-        });
       } else {
         assert(false, "Unresolved error: response is null");
       }
@@ -53,46 +46,5 @@ class BbsNovaDetailRepositoryImpl extends BbsNovaDetailRepository {
       ret = Result.failure(error: error);
     });
     return ret;
-  }
-
-  @override
-  bool saveBookmark({required FetchBbsNovaDetailRepoInput input}) {
-    NovaItemInfo itemInfo = input.itemInfo;
-    itemInfo.isFavorite = !itemInfo.isFavorite;
-    _saveHistory(
-        detailItem: BbsNovaDetailItem(
-            itemInfo: itemInfo, bodyString: input.htmlText ?? ''),
-        isBookmark: true);
-    return true;
-  }
-
-  void _saveHistory({BbsNovaDetailItem? detailItem, bool isBookmark = false}) {
-    if (detailItem != null) {
-      HistorioInfo historioInfo = () {
-        HistorioInfo info = HistorioInfo();
-        info.category = 'bbs';
-        info.id = info.hashCode;
-        info.createdAt = DateTime.now();
-        info.htmlText = detailItem.toHtmlString();
-        info.itemInfo = detailItem.itemInfo;
-        return info;
-      }();
-      HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
-      final json = historioItemRes.toJson();
-      final encoded = jsonEncode(json);
-
-      if (isBookmark) {
-        UserData().saveFavorites(
-            bookmark: encoded,
-            bookmarkIsOn: detailItem.itemInfo.isFavorite,
-            url: historioInfo.itemInfo.urlString,
-            htmlText: historioInfo.htmlText);
-      } else {
-        UserData().insertHistorio(
-            historio: encoded,
-            url: historioInfo.itemInfo.urlString,
-            htmlText: historioInfo.htmlText);
-      }
-    }
   }
 }

--- a/lib/data/repositories/favorites_repository.dart
+++ b/lib/data/repositories/favorites_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:ses_novajoj/foundation/data/result.dart';
 import 'package:ses_novajoj/foundation/data/user_data.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 import 'package:ses_novajoj/domain/entities/favorites_item.dart';
 import 'package:ses_novajoj/domain/repositories/favorites_repository.dart';
@@ -23,5 +24,38 @@ class FavoritesRepositoryImpl extends FavoritesRepository {
     }).toList();
     Result<List<FavoritesItem>> result = Result.success(data: list);
     return result;
+  }
+
+  @override
+  bool saveBookmark({required FetchFavoritesRepoInput input}) {
+    if (input.bookmark == null) {
+      return true;
+    }
+    _saveBookmark(bookmark: input.bookmark);
+    return true;
+  }
+
+  void _saveBookmark({HistorioInfo? bookmark}) async {
+    if (bookmark != null) {
+      HistorioInfo historioInfo = () {
+        HistorioInfo info = HistorioInfo();
+        info.category = bookmark.category;
+        info.id = bookmark.id;
+        info.createdAt = bookmark.createdAt;
+        info.htmlText = bookmark.htmlText;
+        info.itemInfo = bookmark.itemInfo;
+        info.itemInfo.isFavorite = !bookmark.itemInfo.isFavorite;
+        return info;
+      }();
+      HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
+      final json = historioItemRes.toJson();
+      final encoded = jsonEncode(json);
+
+      UserData().saveFavorites(
+          bookmark: encoded,
+          bookmarkIsOn: historioInfo.itemInfo.isFavorite,
+          url: historioInfo.itemInfo.urlString,
+          htmlText: historioInfo.htmlText);
+    }
   }
 }

--- a/lib/data/repositories/historio_repository.dart
+++ b/lib/data/repositories/historio_repository.dart
@@ -15,11 +15,29 @@ class HistorioRepositoryImpl extends HistorioRepository {
   @override
   Future<Result<List<HistorioItem>>> fetchHistorio(
       {required FetchHistorioRepoInput input}) async {
+    // fetch historio
+    final favoriteStrings = UserData().miscFavoritesList;
+    final bookmarks = favoriteStrings.map((elem) {
+      final jsonData = json.decode(elem);
+      HistorioItemRes itemRes = HistorioItemRes.fromJson(jsonData);
+      return HistorioItem.copy(from: itemRes);
+    }).toList();
+    // check hisInfo item is in Favorites.
+    bool _isFavorites(String url) {
+      final arr = bookmarks
+          .where((element) => element.itemInfo.urlString == url)
+          .toList();
+      return arr.isNotEmpty;
+    }
+
+    // fetch historio
     final historioStrings = UserData().miscHistorioList;
     final list = historioStrings.map((elem) {
       final jsonData = json.decode(elem);
       HistorioItemRes itemRes = HistorioItemRes.fromJson(jsonData);
-      return HistorioItem.copy(from: itemRes);
+      HistorioItem ret = HistorioItem.copy(from: itemRes);
+      ret.itemInfo.isFavorite = _isFavorites(ret.itemInfo.urlString);
+      return ret;
     }).toList();
     Result<List<HistorioItem>> result = Result.success(data: list);
     return result;

--- a/lib/data/repositories/historio_repository.dart
+++ b/lib/data/repositories/historio_repository.dart
@@ -3,6 +3,7 @@ import 'package:ses_novajoj/foundation/data/result.dart';
 import 'package:ses_novajoj/domain/entities/historio_item.dart';
 import 'package:ses_novajoj/domain/repositories/historio_repository.dart';
 import 'package:ses_novajoj/foundation/data/user_data.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 
 class HistorioRepositoryImpl extends HistorioRepository {
@@ -41,5 +42,28 @@ class HistorioRepositoryImpl extends HistorioRepository {
     }).toList();
     Result<List<HistorioItem>> result = Result.success(data: list);
     return result;
+  }
+
+  @override
+  void saveNovaDetailHistory({required FetchHistorioRepoInput input}) {
+    if (input.detailItem != null) {
+      HistorioInfo historioInfo = () {
+        HistorioInfo info = HistorioInfo();
+        info.category = input.category ?? '';
+        info.id = info.hashCode;
+        info.createdAt = DateTime.now();
+        info.htmlText = input.detailItem!.toHtmlString();
+        info.itemInfo = input.detailItem!.itemInfo;
+        return info;
+      }();
+      HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
+      final json = historioItemRes.toJson();
+      final encoded = jsonEncode(json);
+
+      UserData().insertHistorio(
+          historio: encoded,
+          url: historioInfo.itemInfo.urlString,
+          htmlText: historioInfo.htmlText);
+    }
   }
 }

--- a/lib/data/repositories/nova_detail_repository.dart
+++ b/lib/data/repositories/nova_detail_repository.dart
@@ -1,10 +1,7 @@
-import 'dart:convert';
-
 import 'package:ses_novajoj/foundation/data/result.dart';
 import 'package:ses_novajoj/foundation/data/user_data.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/networking/api/nova_web_api.dart';
-import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 import 'package:ses_novajoj/networking/response/nova_detalo_item_response.dart';
 import 'package:ses_novajoj/networking/request/nova_detalo_parameter.dart';
 import 'package:ses_novajoj/domain/entities/nova_detail_item.dart';
@@ -41,11 +38,6 @@ class NovaDetailRepositoryImpl extends NovaDetailRepository {
               return info;
             }(),
             bodyString: response.bodyString);
-
-        // save historio
-        Future.delayed(const Duration(seconds: 1), () {
-          _saveHistory(detailItem: retVal);
-        });
       } else {
         assert(false, "Unresolved error: response is null");
       }
@@ -54,46 +46,5 @@ class NovaDetailRepositoryImpl extends NovaDetailRepository {
       ret = Result.failure(error: error);
     });
     return ret;
-  }
-
-  @override
-  bool saveBookmark({required FetchNewsDetailRepoInput input}) {
-    NovaItemInfo itemInfo = input.itemInfo;
-    itemInfo.isFavorite = !itemInfo.isFavorite;
-    _saveHistory(
-        detailItem: NovaDetailItem(
-            itemInfo: itemInfo, bodyString: input.htmlText ?? ''),
-        isBookmark: true);
-    return true;
-  }
-
-  void _saveHistory({NovaDetailItem? detailItem, bool isBookmark = false}) {
-    if (detailItem != null) {
-      HistorioInfo historioInfo = () {
-        HistorioInfo info = HistorioInfo();
-        info.category = 'news';
-        info.id = info.hashCode;
-        info.createdAt = DateTime.now();
-        info.htmlText = detailItem.toHtmlString();
-        info.itemInfo = detailItem.itemInfo;
-        return info;
-      }();
-      HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
-      final json = historioItemRes.toJson();
-      final encoded = jsonEncode(json);
-
-      if (isBookmark) {
-        UserData().saveFavorites(
-            bookmark: encoded,
-            bookmarkIsOn: detailItem.itemInfo.isFavorite,
-            url: historioInfo.itemInfo.urlString,
-            htmlText: historioInfo.htmlText);
-      } else {
-        UserData().insertHistorio(
-            historio: encoded,
-            url: historioInfo.itemInfo.urlString,
-            htmlText: historioInfo.htmlText);
-      }
-    }
   }
 }

--- a/lib/data/repositories/thread_nova_detail_repository.dart
+++ b/lib/data/repositories/thread_nova_detail_repository.dart
@@ -1,10 +1,7 @@
-import 'dart:convert';
-
 import 'package:ses_novajoj/foundation/data/result.dart';
 import 'package:ses_novajoj/foundation/data/user_data.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'package:ses_novajoj/networking/api/thread_nova_web_api.dart';
-import 'package:ses_novajoj/networking/response/historio_item_response.dart';
 import 'package:ses_novajoj/networking/response/thread_detalo_item_response.dart';
 import 'package:ses_novajoj/networking/request/nova_detalo_parameter.dart';
 import 'package:ses_novajoj/domain/entities/thread_nova_detail_item.dart';
@@ -41,11 +38,6 @@ class ThreadNovaDetailRepositoryImpl extends ThreadNovaDetailRepository {
               return info;
             }(),
             bodyString: response.bodyString);
-
-        // save historio
-        Future.delayed(const Duration(seconds: 1), () {
-          _saveHistory(detailItem: retVal);
-        });
       } else {
         assert(false, "Unresolved error: response is null");
       }
@@ -54,47 +46,5 @@ class ThreadNovaDetailRepositoryImpl extends ThreadNovaDetailRepository {
       ret = Result.failure(error: error);
     });
     return ret;
-  }
-
-  @override
-  bool saveBookmark({required FetchThreadNovaDetailRepoInput input}) {
-    NovaItemInfo itemInfo = input.itemInfo;
-    itemInfo.isFavorite = !itemInfo.isFavorite;
-    _saveHistory(
-        detailItem: ThreadNovaDetailItem(
-            itemInfo: itemInfo, bodyString: input.htmlText ?? ''),
-        isBookmark: true);
-    return true;
-  }
-
-  void _saveHistory(
-      {ThreadNovaDetailItem? detailItem, bool isBookmark = false}) {
-    if (detailItem != null) {
-      HistorioInfo historioInfo = () {
-        HistorioInfo info = HistorioInfo();
-        info.category = 'thread';
-        info.id = info.hashCode;
-        info.createdAt = DateTime.now();
-        info.htmlText = detailItem.toHtmlString();
-        info.itemInfo = detailItem.itemInfo;
-        return info;
-      }();
-      HistorioItemRes historioItemRes = HistorioItemRes.as(info: historioInfo);
-      final json = historioItemRes.toJson();
-      final encoded = jsonEncode(json);
-
-      if (isBookmark) {
-        UserData().saveFavorites(
-            bookmark: encoded,
-            bookmarkIsOn: detailItem.itemInfo.isFavorite,
-            url: historioInfo.itemInfo.urlString,
-            htmlText: historioInfo.htmlText);
-      } else {
-        UserData().insertHistorio(
-            historio: encoded,
-            url: historioInfo.itemInfo.urlString,
-            htmlText: historioInfo.htmlText);
-      }
-    }
   }
 }

--- a/lib/domain/repositories/bbs_nova_detail_repository.dart
+++ b/lib/domain/repositories/bbs_nova_detail_repository.dart
@@ -14,5 +14,4 @@ class FetchBbsNovaDetailRepoInput {
 abstract class BbsNovaDetailRepository {
   Future<Result<BbsNovaDetailItem>> fetchBbsNovaDetail(
       {required FetchBbsNovaDetailRepoInput input});
-  bool saveBookmark({required FetchBbsNovaDetailRepoInput input});
 }

--- a/lib/domain/repositories/favorites_repository.dart
+++ b/lib/domain/repositories/favorites_repository.dart
@@ -1,9 +1,14 @@
 import 'package:ses_novajoj/domain/entities/favorites_item.dart';
 import 'package:ses_novajoj/foundation/data/result.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 
-class FetchFavoritesRepoInput {}
+class FetchFavoritesRepoInput {
+  HistorioInfo? bookmark;
+  FetchFavoritesRepoInput({this.bookmark});
+}
 
 abstract class FavoritesRepository {
   Future<Result<List<FavoritesItem>>> fetchFavorites(
       {required FetchFavoritesRepoInput input});
+  bool saveBookmark({required FetchFavoritesRepoInput input});
 }

--- a/lib/domain/repositories/historio_repository.dart
+++ b/lib/domain/repositories/historio_repository.dart
@@ -1,9 +1,16 @@
+import 'package:ses_novajoj/domain/entities/detail_item.dart';
 import 'package:ses_novajoj/domain/entities/historio_item.dart';
 import 'package:ses_novajoj/foundation/data/result.dart';
 
-class FetchHistorioRepoInput {}
+class FetchHistorioRepoInput {
+  DetailItem? detailItem;
+  String? category;
+
+  FetchHistorioRepoInput({this.detailItem, this.category});
+}
 
 abstract class HistorioRepository {
   Future<Result<List<HistorioItem>>> fetchHistorio(
       {required FetchHistorioRepoInput input});
+  void saveNovaDetailHistory({required FetchHistorioRepoInput input});
 }

--- a/lib/domain/repositories/nova_detail_repository.dart
+++ b/lib/domain/repositories/nova_detail_repository.dart
@@ -14,5 +14,4 @@ class FetchNewsDetailRepoInput {
 abstract class NovaDetailRepository {
   Future<Result<NovaDetailItem>> fetchNewsDetail(
       {required FetchNewsDetailRepoInput input});
-  bool saveBookmark({required FetchNewsDetailRepoInput input});
 }

--- a/lib/domain/repositories/thread_nova_detail_repository.dart
+++ b/lib/domain/repositories/thread_nova_detail_repository.dart
@@ -14,5 +14,4 @@ class FetchThreadNovaDetailRepoInput {
 abstract class ThreadNovaDetailRepository {
   Future<Result<ThreadNovaDetailItem>> fetchThreadNovaDetail(
       {required FetchThreadNovaDetailRepoInput input});
-  bool saveBookmark({required FetchThreadNovaDetailRepoInput input});
 }

--- a/lib/domain/usecases/favorites_usecase.dart
+++ b/lib/domain/usecases/favorites_usecase.dart
@@ -1,14 +1,20 @@
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/repositories/favorites_repository.dart';
 import 'package:ses_novajoj/data/repositories/favorites_repository.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 
 import 'favorites_usecase_output.dart';
 
-class FavoritesUseCaseInput {}
+class FavoritesUseCaseInput {
+  HistorioInfo? bookmark;
+
+  FavoritesUseCaseInput({this.bookmark});
+}
 
 abstract class FavoritesUseCase with SimpleBloc<FavoritesUseCaseOutput> {
   Future<FavoritesUseCaseOutput> fetchFavorites(
       {required FavoritesUseCaseInput input});
+  bool saveBookmark({required FavoritesUseCaseInput input});
 }
 
 class FavoritesUseCaseImpl extends FavoritesUseCase {
@@ -28,5 +34,11 @@ class FavoritesUseCaseImpl extends FavoritesUseCase {
         failure: (error) {});
 
     return PresentModel(models: list);
+  }
+
+  @override
+  bool saveBookmark({required FavoritesUseCaseInput input}) {
+    return repository.saveBookmark(
+        input: FetchFavoritesRepoInput(bookmark: input.bookmark));
   }
 }

--- a/lib/domain/usecases/nova_list_usecase.dart
+++ b/lib/domain/usecases/nova_list_usecase.dart
@@ -12,20 +12,20 @@ class NewsListUseCase with SimpleBloc<NovaListUseCaseOutput> {
 
   static final List<FetchNewsListRepoInput> _inputUrlData = [
     FetchNewsListRepoInput(
-        targetUrl: "https://news.6park.com/newspark/index.php",
+        targetUrl: "https://www.6parknews.com/newspark/index.php",
         docType: NovaDocType.list),
     FetchNewsListRepoInput(
-        targetUrl: "https://news.6park.com/newspark/index.php?act=longview",
+        targetUrl: "https://www.6parknews.com/newspark/index.php?act=longview",
         docType: NovaDocType.list),
     FetchNewsListRepoInput(
-        targetUrl: "https://news.6park.com/newspark/index.php?act=gold",
+        targetUrl: "https://www.6parknews.com/newspark/index.php?act=gold",
         docType: NovaDocType.list),
     FetchNewsListRepoInput(
-        targetUrl: "https://news.6park.com/newspark/index.php?act=hotview",
+        targetUrl: "https:/www.6parknews.com/newspark/index.php?act=hotview",
         docType: NovaDocType.table),
     FetchNewsListRepoInput(
         targetUrl:
-            "https://news.6park.com/newspark/index.php?app=news&act=hotreply",
+            "https://www.6parknews.com/newspark/index.php?app=news&act=hotreply",
         docType: NovaDocType.table),
   ];
 

--- a/lib/domain/usecases/thread_nova_detail_usecase.dart
+++ b/lib/domain/usecases/thread_nova_detail_usecase.dart
@@ -1,4 +1,8 @@
+import 'package:ses_novajoj/data/repositories/favorites_repository.dart';
+import 'package:ses_novajoj/data/repositories/historio_repository.dart';
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
+import 'package:ses_novajoj/domain/repositories/favorites_repository.dart';
+import 'package:ses_novajoj/domain/repositories/historio_repository.dart';
 import 'package:ses_novajoj/domain/repositories/thread_nova_detail_repository.dart';
 import 'package:ses_novajoj/data/repositories/thread_nova_detail_repository.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
@@ -20,7 +24,12 @@ abstract class ThreadNovaDetailUseCase
 
 class ThreadNovaDetailUseCaseImpl extends ThreadNovaDetailUseCase {
   final ThreadNovaDetailRepositoryImpl repository;
-  ThreadNovaDetailUseCaseImpl() : repository = ThreadNovaDetailRepositoryImpl();
+  final FavoritesRepository favoriteRepository;
+  final HistorioRepository historioRepository;
+  ThreadNovaDetailUseCaseImpl()
+      : repository = ThreadNovaDetailRepositoryImpl(),
+        favoriteRepository = FavoritesRepositoryImpl(),
+        historioRepository = HistorioRepositoryImpl();
 
   @override
   void fetchThreadNovaDetail(
@@ -30,9 +39,13 @@ class ThreadNovaDetailUseCaseImpl extends ThreadNovaDetailUseCase {
             itemInfo: input.itemInfo, docType: NovaDocType.detail));
 
     result.when(success: (value) {
+      // set result
       streamAdd(PresentModel(
           model: ThreadNovaDetailUseCaseModel(
               value.itemInfo, value.toHtmlString())));
+      // save history
+      historioRepository.saveNovaDetailHistory(
+          input: FetchHistorioRepoInput(detailItem: value, category: 'bbs'));
     }, failure: (error) {
       streamAdd(PresentModel(error: error));
     });
@@ -40,10 +53,15 @@ class ThreadNovaDetailUseCaseImpl extends ThreadNovaDetailUseCase {
 
   @override
   bool saveBookmark({required ThreadNovaDetailUseCaseInput input}) {
-    return repository.saveBookmark(
-        input: FetchThreadNovaDetailRepoInput(
-            itemInfo: input.itemInfo,
-            docType: NovaDocType.detail,
-            htmlText: input.htmlText));
+    HistorioInfo bookmark = HistorioInfo();
+    {
+      bookmark.id = bookmark.hashCode;
+      bookmark.category = "thread";
+      bookmark.itemInfo = input.itemInfo;
+      bookmark.htmlText = input.htmlText;
+      bookmark.createdAt = DateTime.now();
+    }
+    return favoriteRepository.saveBookmark(
+        input: FetchFavoritesRepoInput(bookmark: bookmark));
   }
 }

--- a/lib/foundation/data/user_data.dart
+++ b/lib/foundation/data/user_data.dart
@@ -253,6 +253,29 @@ class UserData {
   }
 
   ///
+  /// removeHistorio
+  ///
+  void removeHistorio({required String url}) {
+    int foundIndex = -1;
+    if (url.isNotEmpty) {
+      foundIndex =
+          _miscHistorioList.indexWhere((element) => element.contains(url));
+    }
+    if (foundIndex >= 0) {
+      _miscHistorioList.removeAt(foundIndex);
+      // delete file
+      _getDataPath(key: _UserDataKey.miscHistory.name).then((path) {
+        File file = File('$path/${url.hashCode}');
+        file.delete();
+      });
+    }
+
+    // save list
+    _saveHistorioList(
+        newValues: _miscHistorioList, key: _UserDataKey.miscHistory.name);
+  }
+
+  ///
   /// readHistorioData
   ///
   Future<String> readHistorioData({required String url}) async {
@@ -317,14 +340,16 @@ class UserData {
     }
 
     // save file
-    _getDataPath(key: _UserDataKey.miscFavorites.name).then((path) {
-      // encode
-      Codec<String, String> codec = utf8.fuse(base64);
-      final encoded = codec.encode(htmlText ?? '');
-      // save
-      File file = File('$path/${url.hashCode}');
-      file.writeAsBytes(encoded.codeUnits);
-    });
+    if ((htmlText ?? '').isNotEmpty) {
+      _getDataPath(key: _UserDataKey.miscFavorites.name).then((path) {
+        // encode
+        Codec<String, String> codec = utf8.fuse(base64);
+        final encoded = codec.encode(htmlText ?? '');
+        // save
+        File file = File('$path/${url.hashCode}');
+        file.writeAsBytes(encoded.codeUnits);
+      });
+    }
 
     // save list
     _saveHistorioList(

--- a/lib/scene/favorites/favorites_page.dart
+++ b/lib/scene/favorites/favorites_page.dart
@@ -56,7 +56,10 @@ class _FavoritesPageState extends State<FavoritesPage> {
                             input: FavoritesPresenterInput(
                                 appBarTitle: _appBarTitle,
                                 viewModel: viewModels[selIndex],
-                                completeHandler: () {}));
+                                completeHandler: () {
+                                  // reload if need
+                                  setState(() {});
+                                }));
                       },
                       onThumbnailShowing: (thumbIndex) async {
                         return viewModels[thumbIndex]

--- a/lib/scene/favorites/favorites_presenter.dart
+++ b/lib/scene/favorites/favorites_presenter.dart
@@ -2,6 +2,7 @@ import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
 import 'package:ses_novajoj/domain/usecases/favorites_usecase.dart';
 import 'package:ses_novajoj/domain/usecases/favorites_usecase_output.dart';
 import 'package:ses_novajoj/foundation/data/user_data.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'favorites_presenter_output.dart';
 
 import 'favorites_router.dart';
@@ -10,6 +11,7 @@ class FavoritesPresenterInput {
   String appBarTitle;
   FavoritesViewModel? viewModel;
   Object? completeHandler;
+  HistorioInfo? bookmark;
   FavoritesPresenterInput(
       {required this.appBarTitle, this.viewModel, this.completeHandler});
 }
@@ -19,6 +21,7 @@ abstract class FavoritesPresenter with SimpleBloc<FavoritesPresenterOutput> {
       {required FavoritesPresenterInput input});
   void eventViewWebPage(Object context,
       {required FavoritesPresenterInput input});
+  bool saveBookmark({required FavoritesPresenterInput input});
 }
 
 class FavoritesPresenterImpl extends FavoritesPresenter {
@@ -45,12 +48,19 @@ class FavoritesPresenterImpl extends FavoritesPresenter {
     _viewSelectPage(context, input: input);
   }
 
+  @override
+  bool saveBookmark({required FavoritesPresenterInput input}) {
+    return useCase.saveBookmark(
+        input: FavoritesUseCaseInput(bookmark: input.bookmark));
+  }
+
   void _viewSelectPage(Object context,
       {required FavoritesPresenterInput input}) async {
     // remove selected favorite
     final itemInfo = input.viewModel?.bookmark.itemInfo;
     void removeAction() {
-      UserData().saveFavorites(bookmark: '', url: itemInfo?.urlString ?? '');
+      useCase.saveBookmark(
+          input: FavoritesUseCaseInput(bookmark: input.bookmark));
     }
 
     router.gotoWebPage(context,

--- a/lib/scene/favorites/favorites_presenter.dart
+++ b/lib/scene/favorites/favorites_presenter.dart
@@ -47,11 +47,18 @@ class FavoritesPresenterImpl extends FavoritesPresenter {
 
   void _viewSelectPage(Object context,
       {required FavoritesPresenterInput input}) async {
+    // remove selected favorite
+    final itemInfo = input.viewModel?.bookmark.itemInfo;
+    void removeAction() {
+      UserData().saveFavorites(bookmark: '', url: itemInfo?.urlString ?? '');
+    }
+
     router.gotoWebPage(context,
         appBarTitle: input.appBarTitle,
-        itemInfo: input.viewModel!.bookmark.itemInfo,
-        htmlText: await UserData().readFavoriteData(
-            url: input.viewModel?.bookmark.itemInfo.urlString ?? ''),
+        itemInfo: itemInfo,
+        htmlText:
+            await UserData().readFavoriteData(url: itemInfo?.urlString ?? ''),
+        removeAction: removeAction,
         completeHandler: input.completeHandler);
   }
 }

--- a/lib/scene/favorites/favorites_presenter_output.dart
+++ b/lib/scene/favorites/favorites_presenter_output.dart
@@ -1,6 +1,5 @@
 import 'package:ses_novajoj/foundation/data/date_util.dart';
 import 'package:ses_novajoj/foundation/data/user_types.dart';
-import 'package:ses_novajoj/foundation/data/user_types_descript.dart';
 import 'package:ses_novajoj/domain/usecases/favorites_usecase_output.dart';
 
 abstract class FavoritesPresenterOutput {}

--- a/lib/scene/favorites/favorites_router.dart
+++ b/lib/scene/favorites/favorites_router.dart
@@ -24,13 +24,28 @@ class FavoritesRouterImpl extends FavoritesRouter {
     // customize menu itemsz of detail page
     BuildContext context_ = context as BuildContext;
 
+    final menuActions = [
+      null,
+      removeAction == null
+          ? null
+          : () {
+              Navigator.of(context_).pop();
+              if (removeAction is Function) {
+                removeAction.call();
+              }
+            }
+    ];
+
     // Transfer to web page / detail page.
     Navigator.pushNamed(context_, ScreenRouteName.webPage.name, arguments: {
       WebPageParamKeys.appBarTitle: appBarTitle,
       WebPageParamKeys.itemInfo: itemInfo,
       WebPageParamKeys.htmlText: htmlText,
-      WebPageParamKeys.menuItems: null,
-      WebPageParamKeys.menuActions: null
+      WebPageParamKeys.menuItems: [
+        DetailMenuItem.openOriginal,
+        DetailMenuItem.removeSettings
+      ],
+      WebPageParamKeys.menuActions: menuActions
     }).then((value) {
       if (completeHandler is Function) {
         completeHandler.call();

--- a/lib/scene/historio/historio_page.dart
+++ b/lib/scene/historio/historio_page.dart
@@ -57,7 +57,9 @@ class _HistorioPageState extends State<HistorioPage> {
                             input: HistorioPresenterInput(
                                 appBarTitle: _appBarTitle,
                                 viewModel: viewModels[selIndex],
-                                completeHandler: () {}));
+                                completeHandler: () {
+                                  setState(() {});
+                                }));
                       },
                       onThumbnailShowing: (thumbIndex) async {
                         return viewModels[thumbIndex]

--- a/lib/scene/historio/historio_presenter.dart
+++ b/lib/scene/historio/historio_presenter.dart
@@ -1,7 +1,9 @@
 import 'package:ses_novajoj/domain/foundation/bloc/simple_bloc.dart';
+import 'package:ses_novajoj/domain/usecases/favorites_usecase.dart';
 import 'package:ses_novajoj/domain/usecases/historio_usecase.dart';
 import 'package:ses_novajoj/domain/usecases/historio_usecase_output.dart';
 import 'package:ses_novajoj/foundation/data/user_data.dart';
+import 'package:ses_novajoj/foundation/data/user_types.dart';
 import 'historio_presenter_output.dart';
 
 import 'historio_router.dart';
@@ -23,10 +25,12 @@ abstract class HistorioPresenter with SimpleBloc<HistorioPresenterOutput> {
 
 class HistorioPresenterImpl extends HistorioPresenter {
   final HistorioUseCase useCase;
+  final FavoritesUseCase favoriteUseCase;
   final HistorioRouter router;
 
   HistorioPresenterImpl({required this.router})
-      : useCase = HistorioUseCaseImpl();
+      : useCase = HistorioUseCaseImpl(),
+        favoriteUseCase = FavoritesUseCaseImpl();
 
   @override
   Future<HistorioPresenterOutput> eventViewReady(
@@ -49,15 +53,28 @@ class HistorioPresenterImpl extends HistorioPresenter {
       {required HistorioPresenterInput input}) async {
     // remove selected historio
     final itemInfo = input.viewModel?.hisInfo.itemInfo;
+    final htmlText =
+        await UserData().readHistorioData(url: itemInfo?.urlString ?? '');
+    HistorioInfo? bookmark = input.viewModel?.hisInfo;
+    bookmark?.htmlText = htmlText;
+    void changeFavoriteAction() {
+      favoriteUseCase.saveBookmark(
+          input: FavoritesUseCaseInput(bookmark: bookmark));
+    }
+
     void removeAction() {
-      UserData().removeHistorio(url: itemInfo?.urlString ?? '');
+      UserData().saveFavorites(
+          bookmark: '',
+          bookmarkIsOn: itemInfo?.isFavorite ?? false,
+          url: itemInfo?.urlString ?? '');
     }
 
     router.gotoWebPage(context,
         appBarTitle: input.appBarTitle,
         itemInfo: itemInfo,
-        htmlText:
-            await UserData().readHistorioData(url: itemInfo?.urlString ?? ''),
+        htmlText: htmlText,
+        changeFavoriteAction:
+            itemInfo?.isFavorite == false ? changeFavoriteAction : null,
         removeAction: removeAction,
         completeHandler: input.completeHandler);
   }

--- a/lib/scene/historio/historio_presenter.dart
+++ b/lib/scene/historio/historio_presenter.dart
@@ -47,11 +47,18 @@ class HistorioPresenterImpl extends HistorioPresenter {
 
   void _viewSelectPage(Object context,
       {required HistorioPresenterInput input}) async {
+    // remove selected historio
+    final itemInfo = input.viewModel?.hisInfo.itemInfo;
+    void removeAction() {
+      UserData().removeHistorio(url: itemInfo?.urlString ?? '');
+    }
+
     router.gotoWebPage(context,
         appBarTitle: input.appBarTitle,
-        itemInfo: input.viewModel!.hisInfo.itemInfo,
-        htmlText: await UserData().readHistorioData(
-            url: input.viewModel?.hisInfo.itemInfo.urlString ?? ''),
+        itemInfo: itemInfo,
+        htmlText:
+            await UserData().readHistorioData(url: itemInfo?.urlString ?? ''),
+        removeAction: removeAction,
         completeHandler: input.completeHandler);
   }
 }

--- a/lib/scene/historio/historio_router.dart
+++ b/lib/scene/historio/historio_router.dart
@@ -24,13 +24,28 @@ class HistorioRouterImpl extends HistorioRouter {
     // customize menu itemsz of detail page
     BuildContext context_ = context as BuildContext;
 
+    final menuActions = [
+      null,
+      removeAction == null
+          ? null
+          : () {
+              Navigator.of(context_).pop();
+              if (removeAction is Function) {
+                removeAction.call();
+              }
+            }
+    ];
+
     // Transfer to web page / detail page.
     Navigator.pushNamed(context_, ScreenRouteName.webPage.name, arguments: {
       WebPageParamKeys.appBarTitle: appBarTitle,
       WebPageParamKeys.itemInfo: itemInfo,
       WebPageParamKeys.htmlText: htmlText,
-      WebPageParamKeys.menuItems: null,
-      WebPageParamKeys.menuActions: null
+      WebPageParamKeys.menuItems: [
+        DetailMenuItem.openOriginal,
+        DetailMenuItem.removeFavoriteOnly
+      ],
+      WebPageParamKeys.menuActions: menuActions
     }).then((value) {
       if (completeHandler is Function) {
         completeHandler.call();

--- a/lib/scene/historio/historio_router.dart
+++ b/lib/scene/historio/historio_router.dart
@@ -8,6 +8,7 @@ abstract class HistorioRouter {
       Object? itemInfo,
       Object? htmlText,
       Object? removeAction,
+      Object? changeFavoriteAction,
       Object? completeHandler});
 }
 
@@ -20,12 +21,21 @@ class HistorioRouterImpl extends HistorioRouter {
       Object? itemInfo,
       Object? htmlText,
       Object? removeAction,
+      Object? changeFavoriteAction,
       Object? completeHandler}) {
     // customize menu itemsz of detail page
     BuildContext context_ = context as BuildContext;
 
     final menuActions = [
       null,
+      changeFavoriteAction == null
+          ? null
+          : () {
+              Navigator.of(context_).pop();
+              if (changeFavoriteAction is Function) {
+                changeFavoriteAction.call();
+              }
+            },
       removeAction == null
           ? null
           : () {
@@ -43,7 +53,8 @@ class HistorioRouterImpl extends HistorioRouter {
       WebPageParamKeys.htmlText: htmlText,
       WebPageParamKeys.menuItems: [
         DetailMenuItem.openOriginal,
-        DetailMenuItem.removeFavoriteOnly
+        DetailMenuItem.favorite,
+        DetailMenuItem.removeSettings
       ],
       WebPageParamKeys.menuActions: menuActions
     }).then((value) {

--- a/lib/scene/misc_info_list/misc_info_list_page.dart
+++ b/lib/scene/misc_info_list/misc_info_list_page.dart
@@ -195,6 +195,9 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
             element.itemInfo.serviceType == ServiceType.none &&
             element.bookmark != null)
         .toList();
+    if ((bookmarks ?? []).isEmpty) {
+      return const SizedBox(height: 0);
+    }
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceFavorites ?? '',
       rowTitles: _buildRowFavoritesWidgets(bookmarks?.take(5).toList()),
@@ -235,6 +238,9 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
             element.itemInfo.serviceType == ServiceType.none &&
             element.hisInfo != null)
         .toList();
+    if ((hisInfos ?? []).isEmpty) {
+      return const SizedBox(height: 0);
+    }
     return InfoServiceCell(
       sectionTitle: UseL10n.of(context)?.infoServiceHistory ?? '',
       rowTitles: _buildRowHistorioWidgets(hisInfos?.take(5).toList()),
@@ -320,7 +326,10 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
                         viewModelList: infos,
                         serviceType: ServiceType.none,
                         itemIndex: index,
-                        completeHandler: () {}));
+                        completeHandler: () {
+                          widget.presenter.eventViewReady(
+                              input: MiscInfoListPresenterInput());
+                        }));
               },
               onThumbnailShowing: (thumbIndex) async {
                 return infos[idx].itemInfo.thunnailUrlString;
@@ -349,7 +358,10 @@ class _MiscInfoListPageState extends State<MiscInfoListPage> {
                         viewModelList: infos,
                         serviceType: ServiceType.none,
                         itemIndex: index,
-                        completeHandler: () {}));
+                        completeHandler: () {
+                          widget.presenter.eventViewReady(
+                              input: MiscInfoListPresenterInput());
+                        }));
               },
               onThumbnailShowing: (thumbIndex) async {
                 return infos[idx].itemInfo.thunnailUrlString;

--- a/lib/scene/misc_info_list/misc_info_list_presenter.dart
+++ b/lib/scene/misc_info_list/misc_info_list_presenter.dart
@@ -87,11 +87,18 @@ class MiscInfoListPresenterImpl extends MiscInfoListPresenter {
   @override
   void eventViewHistorioWebPage(Object context,
       {required MiscInfoListPresenterInput input}) async {
+    // remove selected favorite if need
+    final itemInfo = input.viewModelList?[input.itemIndex].itemInfo;
+    void removeAction() {
+      // remove selected favorite
+      UserData().removeHistorio(url: itemInfo?.urlString ?? '');
+    }
+
     router.gotoHistorioWebPage(context,
-        itemInfo: input.viewModelList?[input.itemIndex].itemInfo,
-        htmlText: await UserData().readHistorioData(
-            url:
-                input.viewModelList?[input.itemIndex].itemInfo.urlString ?? ''),
+        itemInfo: itemInfo,
+        htmlText:
+            await UserData().readHistorioData(url: itemInfo?.urlString ?? ''),
+        removeAction: removeAction,
         appBarTitle: input.appBarTitle,
         completeHandler: input.completeHandler);
   }
@@ -108,11 +115,18 @@ class MiscInfoListPresenterImpl extends MiscInfoListPresenter {
   @override
   void eventViewFavoritesWebPage(Object context,
       {required MiscInfoListPresenterInput input}) async {
+    // remove selected favorite if need
+    final itemInfo = input.viewModelList?[input.itemIndex].itemInfo;
+    void removeAction() {
+      // remove selected favorite
+      UserData().saveFavorites(bookmark: '', url: itemInfo?.urlString);
+    }
+
     router.gotoFavoritesWebPage(context,
-        itemInfo: input.viewModelList?[input.itemIndex].itemInfo,
-        htmlText: await UserData().readFavoriteData(
-            url:
-                input.viewModelList?[input.itemIndex].itemInfo.urlString ?? ''),
+        itemInfo: itemInfo,
+        htmlText:
+            await UserData().readFavoriteData(url: itemInfo?.urlString ?? ''),
+        removeAction: removeAction,
         appBarTitle: input.appBarTitle,
         completeHandler: input.completeHandler);
   }

--- a/lib/scene/misc_info_list/misc_info_list_router.dart
+++ b/lib/scene/misc_info_list/misc_info_list_router.dart
@@ -17,6 +17,7 @@ abstract class MiscInfoListRouter {
       Object? itemInfo,
       Object? htmlText,
       Object? removeAction,
+      Object? changeFavoriteAction,
       Object? completeHandler});
   void gotoFavoritesWebPage(Object context,
       {required String appBarTitle,
@@ -131,11 +132,20 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
       Object? itemInfo,
       Object? htmlText,
       Object? removeAction,
+      Object? changeFavoriteAction,
       Object? completeHandler}) {
     // customize menu itemsz of detail page
     BuildContext context_ = context as BuildContext;
     final menuActions = [
       null,
+      changeFavoriteAction == null
+          ? null
+          : () {
+              Navigator.of(context_).pop();
+              if (changeFavoriteAction is Function) {
+                changeFavoriteAction.call();
+              }
+            },
       removeAction == null
           ? null
           : () {
@@ -153,6 +163,7 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
       WebPageParamKeys.htmlText: htmlText,
       WebPageParamKeys.menuItems: [
         DetailMenuItem.openOriginal,
+        DetailMenuItem.favorite,
         DetailMenuItem.removeSettings
       ],
       WebPageParamKeys.menuActions: menuActions

--- a/lib/scene/misc_info_list/misc_info_list_router.dart
+++ b/lib/scene/misc_info_list/misc_info_list_router.dart
@@ -105,9 +105,6 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
               if (removeAction is Function) {
                 removeAction.call();
               }
-              if (completeHandler is Function) {
-                completeHandler.call();
-              }
             }
     ];
 
@@ -137,13 +134,28 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
       Object? completeHandler}) {
     // customize menu itemsz of detail page
     BuildContext context_ = context as BuildContext;
+    final menuActions = [
+      null,
+      removeAction == null
+          ? null
+          : () {
+              Navigator.of(context_).pop();
+              if (removeAction is Function) {
+                removeAction.call();
+              }
+            }
+    ];
+
     // Transfer to web page / detail page.
     Navigator.pushNamed(context_, ScreenRouteName.webPage.name, arguments: {
       WebPageParamKeys.appBarTitle: appBarTitle,
       WebPageParamKeys.itemInfo: itemInfo,
       WebPageParamKeys.htmlText: htmlText,
-      WebPageParamKeys.menuItems: null,
-      WebPageParamKeys.menuActions: null
+      WebPageParamKeys.menuItems: [
+        DetailMenuItem.openOriginal,
+        DetailMenuItem.removeSettings
+      ],
+      WebPageParamKeys.menuActions: menuActions
     }).then((value) {
       if (completeHandler is Function) {
         completeHandler.call();
@@ -160,13 +172,29 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
       Object? completeHandler}) {
     // customize menu itemsz of detail page
     BuildContext context_ = context as BuildContext;
+
+    final menuActions = [
+      null,
+      removeAction == null
+          ? null
+          : () {
+              Navigator.of(context_).pop();
+              if (removeAction is Function) {
+                removeAction.call();
+              }
+            }
+    ];
+
     // Transfer to web page / detail page.
     Navigator.pushNamed(context_, ScreenRouteName.webPage.name, arguments: {
       WebPageParamKeys.appBarTitle: appBarTitle,
       WebPageParamKeys.itemInfo: itemInfo,
       WebPageParamKeys.htmlText: htmlText,
-      WebPageParamKeys.menuItems: null,
-      WebPageParamKeys.menuActions: null
+      WebPageParamKeys.menuItems: [
+        DetailMenuItem.openOriginal,
+        DetailMenuItem.removeSettings
+      ],
+      WebPageParamKeys.menuActions: menuActions
     }).then((value) {
       if (completeHandler is Function) {
         completeHandler.call();
@@ -208,9 +236,6 @@ class MiscInfoListRouterImpl extends MiscInfoListRouter {
               Navigator.of(context_).pop();
               if (removeAction is Function) {
                 removeAction.call();
-              }
-              if (completeHandler is Function) {
-                completeHandler.call();
               }
             }
     ];

--- a/lib/scene/tabs/tabs_page.dart
+++ b/lib/scene/tabs/tabs_page.dart
@@ -1,6 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:ses_novajoj/l10n/l10n.dart';
-import 'package:ses_novajoj/foundation/log_util.dart';
 import 'package:ses_novajoj/scene/tabs/tabs_presenter.dart';
 import 'package:ses_novajoj/scene/top_list/top_list_page_builder.dart';
 import 'package:ses_novajoj/scene/bbs_main/bbs_main_page_builder.dart';
@@ -17,6 +19,8 @@ class TabsPage extends StatefulWidget {
 }
 
 class _TabsPageState extends State<TabsPage> with WidgetsBindingObserver {
+  static const MethodChannel _channel = MethodChannel('move_to_background');
+
   int _selectedIndex = 0;
   late final List<String> _tabTitles = [
     L10n.of(context)?.tabBarNameHome ?? '',
@@ -55,8 +59,16 @@ class _TabsPageState extends State<TabsPage> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     return WillPopScope(
         onWillPop: () async {
-          log.info('The user tries to pop()');
-          return false;
+          if (Platform.isAndroid) {
+            if (Navigator.of(context).canPop()) {
+              _channel.invokeMethod('moveTaskToBack');
+              return Future.value(false);
+            } else {
+              return Future.value(false);
+            }
+          } else {
+            return Future.value(true);
+          }
         },
         child: Scaffold(
           body: IndexedStack(


### PR DESCRIPTION
Favorites/History page (phase-13_1)

Misc info list page:

- fix: prevent from showing Favorites/Historio area if no data
- add: add a remove settings item when transfer into Favorites/Historio web page.

Favorite page:

- add:  add a remove settings item when transfer into its web page.

Historio page:

- add:  add a remove settings item when transfer into its web page.

Other:

- add: add a method for removing historio data.

Favorites/History page (phase-13_2)

Historio page:

- add:  supports saving favorites settings item when transfer into its web page.

Other:

- add: saves favorites via Favorites(Usecase/Repository).

Favorites/History page (phase-13_3)

Favorites Repository

- add:  supports saving favorites

Historio Repository

- add:  supports saving history.

Other:

bbs detail/nova detail/thread detail
- refatoring: calls `Favorites Repository` to save favorites, removes unnecessary codes.

Favorites/History page (phase-13_4)

misc info select

- add:  supports saving favorites on historio section

Other

top list :
- fix: replaces new urls of showing top list.