### PR TITLE
Feature/sn 052 nova list info search

### DIFF
--- a/lib/data/repositories/bbs_select_list_repository.dart
+++ b/lib/data/repositories/bbs_select_list_repository.dart
@@ -74,7 +74,7 @@ class BbsNovaSelectListRepositoryImpl extends BbsNovaSelectListRepository {
         ret = Result.failure(error: error);
       });
     } else {
-      _estimatedPageCnt = 10; // defalut value
+      _estimatedPageCnt = 10; // default value
       // fetch next page data
       final result = await _api.fetchSelectList(
           parameter:

--- a/lib/data/repositories/nova_list_repository.dart
+++ b/lib/data/repositories/nova_list_repository.dart
@@ -7,6 +7,8 @@ import 'package:ses_novajoj/networking/response/nova_list_response.dart';
 
 class NovaListRepositoryImpl extends NovaListRepository {
   final NovaWebApi _api;
+  int _estimatedPageCnt = 50;
+  String _prevSearchedKeyword = '';
 
   // sigleton
   static final NovaListRepositoryImpl _instance =
@@ -17,28 +19,73 @@ class NovaListRepositoryImpl extends NovaListRepository {
   @override
   Future<Result<List<NovaListItem>>> fetchNewsList(
       {required FetchNewsListRepoInput input}) async {
-    String targetUrl =
-        input.targetUrl.replaceAll('{{page}}', '${input.pageIndex}');
-    Result<List<NovaListItemRes>> result = await _api.fetchNovaList(
-        parameter:
-            NovaItemParameter(targetUrl: targetUrl, docType: input.docType));
+    String targetUrl = input.searchedKeyword.isNotEmpty
+        ? input.searchedUrl.replaceAll('{{page}}', '${input.pageIndex}')
+        : input.targetUrl.replaceAll('{{page}}', '${input.pageIndex}');
 
+    List<NovaListItem> list = [];
     late Result<List<NovaListItem>> ret;
-    List<NovaListItem> novaItems = <NovaListItem>[];
-    result.when(success: (response) {
-      for (var item in response) {
-        NovaListItem retItem = NovaListItem(
-          itemInfo: item.itemInfo,
-        );
-        retItem.itemInfo.pageCount =
-            targetUrl == input.targetUrl ? 1 : 50; //default
-        retItem.itemInfo.pageNumber = input.pageIndex;
-        novaItems.add(retItem);
+
+    Result<List<NovaListItem>> setReturnVal<T>(T response, bool searched) {
+      if (response is List) {
+        for (var item in response) {
+          NovaListItem retItem = NovaListItem(
+            itemInfo: item.itemInfo,
+          );
+          retItem.itemInfo.pageCount = () {
+            int retCnt =
+                targetUrl == input.targetUrl ? 1 : _estimatedPageCnt; //default
+            if (searched) {
+              if (response.length > 90) {
+                retCnt = input.pageIndex + 1;
+              } else {
+                retCnt = 1;
+              }
+              _estimatedPageCnt = retCnt;
+            }
+            retCnt = _estimatedPageCnt > retCnt ? _estimatedPageCnt : retCnt;
+            return retCnt;
+          }();
+          retItem.itemInfo.pageNumber = input.pageIndex;
+          list.add(retItem);
+        }
+        return Result.success(data: list);
+      } else {
+        return const Result.success(data: []);
       }
-      ret = Result.success(data: novaItems);
-    }, failure: (error) {
-      ret = Result.failure(error: error);
-    });
+    }
+
+    if (targetUrl.contains('{{keywords}}')) {
+      if (_prevSearchedKeyword.isEmpty) {
+        _prevSearchedKeyword = input.searchedKeyword;
+      }
+      // if targetUrl is different from previos one except '&p99', reset _estimatedPageCnt as default.
+      if (_prevSearchedKeyword != input.searchedKeyword) {
+        _prevSearchedKeyword = input.searchedKeyword;
+        _estimatedPageCnt = 10; // default value
+      }
+      // fetch next page data
+      targetUrl = targetUrl.replaceAll('{{keywords}}', input.searchedKeyword);
+      final result = await _api.fetchSearchedResult(
+          parameter:
+              NovaItemParameter(targetUrl: targetUrl, docType: input.docType));
+      result.when(success: (response) {
+        ret = setReturnVal(response, true);
+      }, failure: (error) {
+        ret = Result.failure(error: error);
+      });
+    } else {
+      _estimatedPageCnt = 50; // default value
+      // fetch next page data
+      Result<List<NovaListItemRes>> result = await _api.fetchNovaList(
+          parameter:
+              NovaItemParameter(targetUrl: targetUrl, docType: input.docType));
+      result.when(success: (response) {
+        ret = setReturnVal(response, false);
+      }, failure: (error) {
+        ret = Result.failure(error: error);
+      });
+    }
 
     return ret;
   }

--- a/lib/data/repositories/nova_list_repository.dart
+++ b/lib/data/repositories/nova_list_repository.dart
@@ -36,10 +36,10 @@ class NovaListRepositoryImpl extends NovaListRepository {
             int retCnt =
                 targetUrl == input.targetUrl ? 1 : _estimatedPageCnt; //default
             if (searched) {
-              if (response.length > 90) {
-                retCnt = input.pageIndex + 1;
+              if (response.length >= 100) {
+                retCnt = 10;
               } else {
-                retCnt = 1;
+                retCnt = input.pageIndex;
               }
               _estimatedPageCnt = retCnt;
             }

--- a/lib/domain/repositories/nova_list_repository.dart
+++ b/lib/domain/repositories/nova_list_repository.dart
@@ -4,11 +4,17 @@ import 'package:ses_novajoj/domain/entities/nova_list_item.dart';
 
 class FetchNewsListRepoInput {
   String targetUrl;
+  String searchedUrl;
+  String searchedKeyword;
   int pageIndex;
   NovaDocType docType;
 
   FetchNewsListRepoInput(
-      {required this.targetUrl, this.pageIndex = 1, required this.docType});
+      {required this.targetUrl,
+      this.searchedUrl = '',
+      this.searchedKeyword = '',
+      this.pageIndex = 1,
+      required this.docType});
 }
 
 abstract class NovaListRepository {

--- a/lib/domain/usecases/nova_list_usecase.dart
+++ b/lib/domain/usecases/nova_list_usecase.dart
@@ -13,6 +13,8 @@ class NewsListUseCase with SimpleBloc<NovaListUseCaseOutput> {
   static final List<FetchNewsListRepoInput> _inputUrlData = [
     FetchNewsListRepoInput(
         targetUrl: "https://www.6parknews.com/newspark/index.php?p={{page}}",
+        searchedUrl:
+            "https://www.6parknews.com/newspark/index.php?act=newssearch&app=news&keywords={{keywords}}&p={{page}}",
         docType: NovaDocType.list),
     FetchNewsListRepoInput(
         targetUrl: "https://www.6parknews.com/newspark/index.php?act=longview",
@@ -32,9 +34,11 @@ class NewsListUseCase with SimpleBloc<NovaListUseCaseOutput> {
 
   void fetchNewsList(
       {required int targetUrlIndex,
+      String? searchedKeyword,
       int? targetPageIndex,
       String? prefixTitle}) async {
     _inputUrlData[targetUrlIndex].pageIndex = targetPageIndex ?? 0;
+    _inputUrlData[targetUrlIndex].searchedKeyword = searchedKeyword ?? '';
     final result =
         await repository.fetchNewsList(input: _inputUrlData[targetUrlIndex]);
 

--- a/lib/scene/bbs_select_list/bbs_select_list_page.dart
+++ b/lib/scene/bbs_select_list/bbs_select_list_page.dart
@@ -394,8 +394,8 @@ class _BbsSelectListPageState extends State<BbsSelectListPage> {
       {bool isReloaded = false,
       String searchedKeyword = '',
       bool searchResultIsCleared = false}) {
-    if (_prevSearchedKeyword != _currentSearchedKeyword) {
-      _prevSearchedKeyword = _currentSearchedKeyword;
+    if (_prevSearchedKeyword != searchedKeyword) {
+      _prevSearchedKeyword = searchedKeyword;
       _currentPageIndex = 1;
     }
     _waitingCount = 0;

--- a/lib/scene/root/search_page.dart
+++ b/lib/scene/root/search_page.dart
@@ -13,8 +13,9 @@ class SearchPage {
       Function(bool)? cancelAction,
       Function()? openSearchAction,
       Function()? refreshAction}) {
-    return !_searchIsEnabled
+    return !_searchIsEnabled || searchAction == null
         ? AppBar(
+            automaticallyImplyLeading: automaticallyImplyLeading,
             leadingWidth: 25,
             title: Text(appBarTitle),
             backgroundColor: ColorDef.appBarBackColor2,
@@ -28,7 +29,7 @@ class SearchPage {
             automaticallyImplyLeading: automaticallyImplyLeading,
             searchAction: (keyword) {
               _isSearched = true;
-              searchAction?.call(keyword);
+              searchAction.call(keyword);
             },
             cancelAction: () {
               _searchIsEnabled = false;
@@ -51,8 +52,8 @@ class SearchPage {
               },
               icon: const Icon(Icons.search_rounded))),
       SizedBox(
-          width: 45,
-          height: 45,
+          width: 40,
+          height: 40,
           child: IconButton(
               padding: const EdgeInsets.only(top: 5),
               onPressed: refreshAction,

--- a/lib/scene/top_list/top_sub_page.dart
+++ b/lib/scene/top_list/top_sub_page.dart
@@ -8,12 +8,22 @@ import 'package:ses_novajoj/scene/top_list/top_list_presenter_output.dart';
 import 'package:ses_novajoj/scene/widgets/nova_list_cell.dart';
 import 'package:ses_novajoj/scene/widgets/error_view.dart';
 
+class TopSearchKeyItem {
+  bool isReload;
+  bool searchResultIsCleared;
+  String searchedKey;
+  TopSearchKeyItem(
+      {this.isReload = true,
+      this.searchResultIsCleared = false,
+      this.searchedKey = ''});
+}
+
 class TopSubPage extends StatefulWidget {
   final TopListPresenter presenter;
   final int tabIndex;
   final String prefixTitle;
   final String appBarTitle;
-  final StreamController<bool> reloadedController;
+  final StreamController<TopSearchKeyItem> reloadedController;
 
   const TopSubPage(
       {Key? key,
@@ -32,6 +42,7 @@ class _TopSubPageState extends State<TopSubPage>
     with AutomaticKeepAliveClientMixin<TopSubPage> {
   final ScrollController _scrollController = ScrollController();
   int _currentPageIndex = 1;
+  String _prevSearchedKeyword = '';
 
   @override
   bool get wantKeepAlive => true;
@@ -39,8 +50,8 @@ class _TopSubPageState extends State<TopSubPage>
   @override
   void initState() {
     widget.reloadedController.stream.listen((event) {
-      if (event) {
-        _loadData();
+      if (event.isReload) {
+        _loadData(searchedKeyword: event.searchedKey);
       }
     });
     _loadData();
@@ -136,10 +147,19 @@ class _TopSubPageState extends State<TopSubPage>
     );
   }
 
-  void _loadData({bool isReloaded = false}) {
+  void _loadData(
+      {bool isReloaded = false,
+      String searchedKeyword = '',
+      bool searchResultIsCleared = false}) {
+    if (_prevSearchedKeyword != searchedKeyword) {
+      _prevSearchedKeyword = searchedKeyword;
+      _currentPageIndex = 1;
+    }
     // fetch data
     widget.presenter.eventViewReady(
         targetUrlIndex: widget.tabIndex,
+        searchedKeyword: searchedKeyword,
+        searchResultIsCleared: searchResultIsCleared,
         pageIndex: _currentPageIndex,
         prefixTitle: widget.prefixTitle,
         isReloaded: isReloaded);

--- a/lib/scene/top_list/top_sub_page.dart
+++ b/lib/scene/top_list/top_sub_page.dart
@@ -89,7 +89,7 @@ class _TopSubPageState extends State<TopSubPage>
                           index: index,
                           onPageChanged: (pageIndex) {
                             _currentPageIndex = pageIndex;
-                            _loadData();
+                            _loadData(searchedKeyword: _prevSearchedKeyword);
                           },
                           pageEnd: true,
                           onScrollToTop: () {
@@ -108,7 +108,9 @@ class _TopSubPageState extends State<TopSubPage>
                               appBarTitle: widget.appBarTitle,
                               itemInfo: data.viewModelList![selIndex].itemInfo,
                               completeHandler: () {
-                            _loadData(isReloaded: true);
+                            _loadData(
+                                isReloaded: true,
+                                searchedKeyword: _prevSearchedKeyword);
                           });
                         },
                         onThumbnailShowing: (thumbIndex) async {


### PR DESCRIPTION
change ui of `top list`(page) for supporting search(phase-1)

- add NovaSearch Bar widget base on AppBar.
- adapt search event and cancel event to its ui.
- fix: some spell mistakes.

modify `top list` (repo,usecase, presenter) for fetching search results(phase-2)

- modify `eventViewReady`(presenter) method to support Keyword Search feature.
- modify `eventViewReady`(presenter) method to clear search result.
- modify `fetchNewsList`(usecase) method to support Keyword Search feature.
- modify `fetchNewsList`(repo) method to support Keyword Search feature.
- fix: some spell mistakes.

add `top nova list` (search api ) for fetching search results(phase-3)

- add `top nova list` keyword search api.
- modify search result method(repository) when paging fetch.
- modify search result method(top page) when paging fetch.